### PR TITLE
feat(pipeline): add LangGraph graph topology, GraphState schema, and …

### DIFF
--- a/server/app/agents/Agents.md
+++ b/server/app/agents/Agents.md
@@ -1,0 +1,384 @@
+) ingest_node (Preprocessing stage: ingestion + artifact registration)
+
+Purpose: create a session artifact set, sanitize inputs, basic metadata.
+
+Consumes: raw transcript segments, PDFs
+
+Produces: state.transcript, state.documents, initial trace
+
+Deterministic work:
+
+ensure timestamps monotonic
+
+drop empty segments
+
+tag docs by type
+
+Tools used: pdf text extraction tool, table extractor tool
+
+Failure modes: PDF parse fails → mark doc as “unparsed” and continue
+
+B) normalize_transcript_node (Preprocessing stage: complexity + structure analysis)
+
+Purpose: normalize speaker roles, cleanup text, and compute complexity signals that influence later extraction strategy.
+
+Consumes: state.transcript
+
+Produces:
+
+normalized speaker labels (Doctor/Patient/Other)
+
+state.inputs["complexity"] = {...} (e.g., multi-speaker, interruptions)
+
+Deterministic work:
+
+unit normalization (mg, mcg, mmol/L)
+
+expand common abbreviations (optional)
+
+Tools used: optional LLM for diarization correction; rules-based normalizer
+
+Failure modes: speaker unknown → keep as None but tag for extractor
+
+Complexity metrics examples:
+
+num_speakers_detected
+
+avg_segment_length
+
+medical_term_density
+
+contradiction_likelihood (heuristic)
+
+C) segment_and_chunk_node (Preprocessing stage: chunking policy)
+
+Purpose: produce stable chunks for extraction + evidence provenance.
+
+Consumes: normalized transcript + doc texts
+
+Produces: state.chunks
+
+Deterministic work:
+
+chunk transcript by topic/speaker turns (not just fixed token window)
+
+chunk PDFs separately: narrative chunks + table chunks
+
+Tools used: optional semantic splitter (LLM) but preferably deterministic + heuristics
+
+Failure modes: doc too long → cap / multi-pass chunking
+
+Why this matters: good chunking is policy, not capability. It’s a node.
+
+D) extract_candidates_node (Initial Extraction stage)
+
+Purpose: extract candidate facts with confidence + local evidence pointers.
+
+Consumes: state.chunks
+
+Produces: state.candidates (CandidateFact objects)
+
+Deterministic work:
+
+canonicalize entities (drug names, allergies)
+
+assign fact_type with strict schema
+
+Tools used: LLM extraction tool (JSON-only), medical NER tool (optional)
+
+Failure modes: invalid JSON → repair prompt / retry (counts toward budget)
+
+Output quality rule: candidates must always include at least one evidence span (even if weak).
+
+E) retrieve_evidence_node (Evidence Linking stage — “RAG but for provenance”)
+
+Purpose: retrieve additional evidence for each candidate and strengthen traceability.
+
+Consumes: state.candidates, state.chunks, documents
+
+Produces: updates CandidateFact.evidence with stronger spans + ranking
+
+Deterministic work:
+
+deduplicate evidence
+
+enforce snippet length
+
+Tools used: embeddings + vector search, keyword search, reranker
+
+Failure modes: no evidence found → downgrade confidence + flag for review
+
+This is the “anti-chatbot” RAG: retrieval is used to justify fields, not answer questions.
+
+F) fill_structured_record_node (Synthesis stage: record construction)
+
+Purpose: map candidates into a strict structured record schema + build provenance per field.
+
+Consumes: candidates + evidence
+
+Produces: state.record, state.provenance
+
+Deterministic work:
+
+field mapping rules (fact_type → record paths)
+
+merging duplicates (same med, repeated allergy)
+
+prefer higher-confidence facts
+
+Tools used: minimal or none; optionally LLM for complex mapping, but avoid if possible
+
+Failure modes: missing required fields → leave empty but produce validation errors later
+
+G) validate_and_score_node (Validation stage — routing authority)
+
+Purpose: enforce contracts, compute field-level confidence, and detect contradictions.
+
+Consumes: record + provenance + candidates
+
+Produces: state.validation, state.conflicts
+
+Deterministic checks:
+
+schema (types, required fields)
+
+format constraints (DOB ISO date)
+
+sanity constraints (age range, dosages)
+
+cross-field checks (penicillin allergy vs amoxicillin)
+
+Tools used: optional LLM “clinical validator” ONLY for ambiguous cases; deterministic first
+
+Failure modes: too many errors → route to fallback or repair loop
+
+Routing signals set here:
+
+schema_errors → repair
+
+conflicts → conflict resolution
+
+needs_review → human gate
+
+else → generate note
+
+H) repair_node (Refinement stage — bounded)
+
+Purpose: targeted re-extraction or patching based on specific validation failures.
+
+Consumes: validation errors + conflict seeds
+
+Produces: updated candidates/record pieces
+
+Deterministic policy:
+
+max N retries
+
+only retry missing/invalid fields
+
+prohibit rewriting already high-confidence fields
+
+Tools used: constrained LLM prompts (“fill only these fields”), or deterministic regex extraction
+
+Failure modes: budget exceeded → fallback or needs_review
+
+I) conflict_resolution_node (Refinement stage — policy-based)
+
+Purpose: resolve contradictions using policies + evidence.
+
+Consumes: conflict report items + evidence
+
+Produces: resolved conflicts or escalations; patched record/provenance
+
+Deterministic policy examples:
+
+prefer most recent dated source
+
+prefer “med list” doc over transcript mention
+
+if tie → keep both + mark needs_review
+
+Tools used: optional LLM for “resolution rationale”, not for the decision
+
+Failure modes: unresolved → human gate
+
+J) human_review_gate_node (Terminal decision)
+
+Purpose: produce “needs_review” output with crisp questions.
+
+Consumes: unresolved conflicts / low confidence fields
+
+Produces: outputs.status="needs_review", outputs.review_questions
+
+Deterministic behavior:
+
+generate minimal set of questions (1–5)
+
+include evidence snippets in UI (not as questions)
+
+Tools used: optionally LLM to draft question text, but can be template-driven
+
+K) generate_note_node (Synthesis stage)
+
+Purpose: generate final clinical note from structured record only (no hallucinating).
+
+Consumes: state.record
+
+Produces: outputs.clinical_note
+
+Deterministic constraints:
+
+disallow adding concepts not in record
+
+include warnings/conflicts section if present
+
+Tools used: LLM summarizer with strict grounding (“use only provided JSON”)
+
+L) package_outputs_node (Packaging / export stage)
+
+Purpose: assemble final artifacts.
+
+Consumes: record + provenance + validation + conflicts + note
+
+Produces: outputs.*, set done/needs_review/failed
+
+Deterministic work:
+
+JSON export
+
+markdown note export
+
+audit log export
+
+trace summary
+
+3) “Agents” with purpose and boundaries (who does what)
+
+In LangGraph terms, “agent” = a node’s internal reasoning module(s) + tools. Here’s a crisp set of agents that map cleanly to nodes:
+
+Agent A — Transcript Analyst (Preprocessing)
+
+Used by: normalize_transcript_node
+
+Purpose: determine transcript complexity, speaker roles, noisy segments
+
+Output: normalized transcript + complexity report
+
+Hard constraint: never invent medical facts
+
+Agent B — Candidate Extractor (Initial Extraction)
+
+Used by: extract_candidates_node
+
+Purpose: produce typed candidate facts (JSON) with initial evidence spans
+
+Output: CandidateFact[]
+
+Hard constraint: must include evidence spans; no evidence → low confidence
+
+Agent C — Evidence Linker (Provenance Retrieval)
+
+Used by: retrieve_evidence_node
+
+Purpose: strengthen evidence for each candidate across PDFs/transcript
+
+Output: updated candidate evidence ranking
+
+Hard constraint: evidence snippets must be short + exact
+
+Agent D — Record Compiler (Schema Mapper)
+
+Used by: fill_structured_record_node
+
+Purpose: assemble canonical structured record + field provenance
+
+Output: StructuredClinicalRecord, provenance list
+
+Hard constraint: only compile from candidates with evidence
+
+Agent E — Validator (Rules-first)
+
+Used by: validate_and_score_node
+
+Purpose: schema + sanity + cross-field checks; produce validation/conflicts
+
+Output: validation report, conflict report, routing signals
+
+Hard constraint: deterministic rules are primary; LLM only for ambiguity
+
+Agent F — Repair Specialist (Targeted)
+
+Used by: repair_node
+
+Purpose: fix only specific missing/invalid fields; bounded iterations
+
+Output: patched candidates/record, updated confidence
+
+Hard constraint: cannot rewrite already-validated high-confidence fields
+
+Agent G — Conflict Arbiter (Policy-based)
+
+Used by: conflict_resolution_node
+
+Purpose: resolve contradictions using evidence + policy; else escalate
+
+Output: updated record + conflict decisions
+
+Hard constraint: if policy can’t decide, escalate
+
+Agent H — Note Generator (Grounded)
+
+Used by: generate_note_node
+
+Purpose: produce human-readable note grounded in structured record
+
+Output: note text
+
+Hard constraint: no new entities not present in record
+
+Agent I — Review Gatekeeper (HITL)
+
+Used by: human_review_gate_node
+
+Purpose: ask minimal questions needed to resolve uncertainty
+
+Output: review questions + what evidence triggered them
+
+Hard constraint: questions must be answerable and specific
+
+4) Implementation tips that make this “systems” (not chatbot)
+Add a simple state.controls.attempts[node] += 1 helper
+
+Every node increments attempts; repair checks this.
+
+Keep a trace entry per node
+
+Store:
+
+what changed (counts, confidences)
+
+time spent
+
+llm calls used
+
+Enforce “grounding” at the schema boundary
+
+Only allow generate_note_node to read state.record, not raw docs.
+
+5) Mapping to your existing “Fallback Node”
+
+Your fallback is a separate route when:
+
+too many schema errors after repair budget
+
+extraction JSON repeatedly invalid
+
+transcript complexity too high
+
+Fallback behavior:
+
+skip conflict resolution loops
+
+extract only “core fields” (dx, meds, allergies, follow-up)
+
+mark needs_review=True

--- a/server/app/agents/InteractionExamples.md
+++ b/server/app/agents/InteractionExamples.md
@@ -1,0 +1,57 @@
+Demo: “Contradictory Allergy + Medication Across Docs”
+Inputs
+
+Transcript says:
+
+“Patient reports no allergies.”
+
+Later: “Actually, I had a rash with penicillin years ago.”
+
+PDF med list includes:
+
+Amoxicillin prescribed last week
+
+Discharge summary lists:
+
+Allergy: Penicillin (rash)
+
+Expected system behavior (what you show in UI/logs)
+Outputs (artifacts)
+
+Structured record
+
+allergies: [penicillin -> rash]
+
+medications: amoxicillin flagged with contraindication_warning = true
+
+Conflict report
+
+Conflict type: ALLERGY_CONTRADICTION
+
+Evidence:
+
+transcript span A (“no allergies”)
+
+transcript span B (“rash with penicillin”)
+
+discharge summary allergy section
+
+Resolution:
+
+pick “penicillin allergy (rash)” (higher confidence: discharge + later transcript)
+
+Validation report
+
+warning: Medication amoxicillin conflicts with penicillin allergy
+
+status: needs_review = true OR “resolved but flagged” depending on policy
+
+Human review gate
+
+Generates one crisp question:
+
+“Confirm whether amoxicillin is safe given penicillin rash history.”
+
+Clinical note
+
+Includes allergy and warning, with no hallucinated extras.

--- a/server/app/agents/config.py
+++ b/server/app/agents/config.py
@@ -1,0 +1,188 @@
+"""
+AgentContext — Dependency Injection for LangGraph Nodes.
+
+Follows Anthropic's agent pattern: nodes receive capabilities via context,
+they don't reach out and grab their own dependencies. This makes nodes
+testable, composable, and decoupled from infrastructure.
+
+Usage:
+    ctx = AgentContext(
+        patient_service=my_patient_svc,
+        clinical_engine=my_engine,
+        embedding_service=my_embed_svc,
+        llm_factory=lambda: LLMClient(),
+        db_session_factory=SessionLocal,
+    )
+    graph = build_graph(ctx)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+
+if TYPE_CHECKING:
+    from app.core.clinical_suggestions import ClinicalSuggestionEngine
+    from app.core.patient_service import PatientService
+    from app.database.repositories.patient_repo import PatientRepository
+    from app.database.repositories.record_repo import RecordRepository
+    from app.database.repositories.session_repo import SessionRepository
+    from app.models.llm import LLMClient
+    from app.services.embedding_service import EmbeddingService
+    from sqlalchemy.orm import Session as DBSession
+
+
+@dataclass(frozen=True)
+class AgentContext:
+    """
+    Injected context available to every agent node.
+
+    Attributes:
+        patient_service:       Database-backed patient lookup (legacy).
+        clinical_engine:       Clinical suggestion engine.
+        llm_factory:           Callable that returns a fresh LLMClient.
+        embedding_service:     Medical-domain embedding + pgvector ops.
+        patient_repo:          PatientRepository for patient CRUD.
+        record_repo:           RecordRepository for medical record CRUD.
+        session_repo:          SessionRepository for session CRUD.
+        db_session_factory:    Callable that returns a new SQLAlchemy Session.
+        max_llm_calls:         Budget cap on total LLM invocations per run.
+        grounding_threshold:   Min cosine sim for span grounding (Layer 1).
+        persistence_floor:     Min confidence for is_final=True (Layer 3).
+        trace_enabled:         Enable trace logging in controls.trace_log.
+    """
+    patient_service: Optional[PatientService] = None
+    clinical_engine: Optional[ClinicalSuggestionEngine] = None
+    llm_factory: Optional[Callable[[], LLMClient]] = None
+
+    # ── New: DB-aware dependencies ──────────────────────────────────────────
+    embedding_service: Optional[EmbeddingService] = None
+    patient_repo: Optional[PatientRepository] = None
+    record_repo: Optional[RecordRepository] = None
+    session_repo: Optional[SessionRepository] = None
+    db_session_factory: Optional[Callable[[], DBSession]] = None
+
+    # ── Tuning knobs ────────────────────────────────────────────────────────
+    max_llm_calls: int = 30
+    grounding_threshold: float = 0.65
+    persistence_floor: float = 0.60
+    trace_enabled: bool = True
+
+
+def make_node(node_fn: Callable, context: AgentContext) -> Callable:
+    """
+    Bind an AgentContext to a node function.
+
+    Supports two signatures:
+        (state: GraphState) -> GraphState              — context-free node
+        (state: GraphState, ctx: AgentContext) -> GraphState — context-aware node
+
+    Returns a LangGraph-compatible ``(state) -> state`` callable.
+    """
+    import inspect
+    sig = inspect.signature(node_fn)
+    needs_ctx = len(sig.parameters) >= 2
+
+    def wrapped(state: Dict[str, Any]) -> Dict[str, Any]:
+        if needs_ctx:
+            return node_fn(state, context)
+        return node_fn(state)
+
+    # Preserve original name for graph visualisation
+    wrapped.__name__ = node_fn.__name__
+    wrapped.__qualname__ = node_fn.__qualname__
+    return wrapped
+
+
+def create_default_context(
+    db_session=None,
+) -> AgentContext:
+    """
+    Build an AgentContext with live production dependencies.
+
+    Lazily imports heavy modules so the context can be created without
+    triggering torch/pyannote DLL issues at import time.
+
+    Args:
+        db_session: Optional SQLAlchemy Session.  When provided, the
+                    repositories and embedding service are wired up for
+                    full DB integration.  When ``None`` (e.g. in tests),
+                    the pipeline still runs but without persistence.
+    """
+    clinical_engine = None
+    patient_service = None
+    embedding_service = None
+    patient_repo = None
+    record_repo = None
+    session_repo = None
+    db_session_factory = None
+
+    try:
+        from app.core.clinical_suggestions import get_clinical_suggestion_engine
+        clinical_engine = get_clinical_suggestion_engine()
+    except Exception:
+        pass
+
+    def _llm_factory():
+        from app.models.llm import LLMClient
+        return LLMClient()
+
+    # Wire up DB-backed services if a session is provided
+    if db_session is not None:
+        # Quick connectivity check — if DB is unreachable, skip all repos/services
+        # so every downstream node doesn't individually timeout.
+        _db_reachable = False
+        try:
+            from sqlalchemy import text as sa_text
+            db_session.execute(sa_text("SELECT 1"))
+            _db_reachable = True
+        except Exception as e:
+            import logging as _logging
+            _logging.getLogger(__name__).warning(
+                "[AgentContext] DB connection check failed — running without persistence: %s", e
+            )
+
+        if _db_reachable:
+            try:
+                from app.core.patient_service import PatientService
+                patient_service = PatientService(db_session)
+            except Exception:
+                pass
+
+            try:
+                from app.database.repositories.patient_repo import PatientRepository
+                from app.database.repositories.record_repo import RecordRepository
+                from app.database.repositories.session_repo import SessionRepository
+                patient_repo = PatientRepository(db_session)
+                record_repo = RecordRepository(db_session)
+                session_repo = SessionRepository(db_session)
+            except Exception:
+                pass
+
+            try:
+                from app.services.embedding_service import get_embedding_service
+                embedding_service = get_embedding_service(db=db_session)
+            except Exception:
+                pass
+
+            # Factory for fresh sessions (e.g. persist_results commits independently)
+            try:
+                from app.database.session import SessionLocal
+                db_session_factory = SessionLocal
+            except Exception:
+                pass
+
+    return AgentContext(
+        clinical_engine=clinical_engine,
+        patient_service=patient_service,
+        llm_factory=_llm_factory,
+        embedding_service=embedding_service,
+        patient_repo=patient_repo,
+        record_repo=record_repo,
+        session_repo=session_repo,
+        db_session_factory=db_session_factory,
+        max_llm_calls=30,
+        grounding_threshold=0.65,
+        persistence_floor=0.60,
+        trace_enabled=True,
+    )

--- a/server/app/agents/graph.py
+++ b/server/app/agents/graph.py
@@ -1,0 +1,173 @@
+"""
+LangGraph Workflow — Clean Graph Definition.
+
+Single source of truth for the clinical transcription pipeline topology.
+Replaces the inline graph-building in langgraph_runner.py with a
+context-aware, testable graph builder.
+
+Nodes receive services through AgentContext (Anthropic agent pattern) 
+rather than importing them directly.
+
+Pipeline topology (with DB integration):
+  greeting → load_patient_context → ingest → clean → normalize → segment →
+  extract → evidence → fill_record → clinical_suggestions → validate →
+  [repair loop | conflict_resolution | human_review_gate] →
+  generate_note → package_outputs → persist_results → END
+"""
+
+from langgraph.graph import StateGraph, END
+from langgraph.checkpoint.sqlite import SqliteSaver
+from pathlib import Path
+
+from .state import GraphState
+from .config import AgentContext, make_node, create_default_context
+
+# Node imports — each is a pure function (state[, ctx]) -> state
+from .nodes.load_patient_context import load_patient_context_node
+from .nodes.ingest import ingest_transcript_node
+from .nodes.clean import clean_transcription_node
+from .nodes.normalize import normalize_transcript_node
+from .nodes.segment import segment_and_chunk_node
+from .nodes.extract import extract_candidates_node
+from .nodes.evidence import retrieve_evidence_node
+from .nodes.fill_record import fill_structured_record_node
+from .nodes.clinical_suggestions import clinical_suggestions_node
+from .nodes.validate import validate_and_score_node
+from .nodes.repair import repair_node
+from .nodes.conflicts import conflict_resolution_node
+from .nodes.review_gate import human_review_gate_node
+from .nodes.generate_note import generate_note_node
+from .nodes.package import package_outputs_node
+from .nodes.persist_results import persist_results_node
+
+
+# ─── Greeting (lightweight, no context needed) ─────────────────────────────
+
+def greeting_node(state: GraphState) -> GraphState:
+    """Welcome message — seeds initial state."""
+    state = {**state}
+    state["message"] = (
+        f"Welcome back Dr. {state.get('doctor_id', 'Unknown')}. "
+        "I'm Judith, ready to assist with today's transcription session."
+    )
+    return state
+
+
+# ─── Routing helpers ────────────────────────────────────────────────────────
+
+def _route_after_validate(state: GraphState) -> str:
+    """Decide next step after validation: repair, conflict resolution, review, or note."""
+    report = state.get("validation_report") or {}
+    controls = state.get("controls", {})
+    repair_attempts = controls.get("attempts", {}).get("repair", 0)
+
+    # Repair loop (max 3 iterations)
+    if report.get("schema_errors") and repair_attempts < 3:
+        return "repair"
+    if report.get("conflicts"):
+        return "conflict_resolution"
+    if report.get("needs_review"):
+        return "human_review_gate"
+    return "generate_note"
+
+
+def _route_after_conflict(state: GraphState) -> str:
+    """Decide next step after conflict resolution."""
+    report = state.get("conflict_report") or {}
+    if report.get("unresolved"):
+        return "human_review_gate"
+    return "generate_note"
+
+
+# ─── Graph builder ──────────────────────────────────────────────────────────
+
+def build_graph(
+    ctx: AgentContext | None = None,
+    checkpoint_path: str | None = None,
+    enable_interrupts: bool = True,
+):
+    """
+    Build and compile the clinical transcription LangGraph.
+
+    Args:
+        ctx:               AgentContext with injected services.
+                           Falls back to ``create_default_context()`` if None.
+        checkpoint_path:   Path to SQLite checkpoint DB.
+                           Defaults to ``storage/checkpoints.db``.
+        enable_interrupts: Pause before human_review_gate for approval.
+
+    Returns:
+        Compiled LangGraph application.
+    """
+    if ctx is None:
+        ctx = create_default_context()
+
+    graph = StateGraph(GraphState)
+
+    # ── Register nodes (context injected via make_node) ─────────────────────
+    nodes = {
+        "greeting":               greeting_node,
+        "load_patient_context":   load_patient_context_node,
+        "ingest":                 ingest_transcript_node,
+        "clean_transcription":    clean_transcription_node,
+        "normalize_transcript":   normalize_transcript_node,
+        "segment_and_chunk":      segment_and_chunk_node,
+        "extract_candidates":     extract_candidates_node,
+        "retrieve_evidence":      retrieve_evidence_node,
+        "fill_structured_record": fill_structured_record_node,
+        "clinical_suggestions":   clinical_suggestions_node,
+        "validate_and_score":     validate_and_score_node,
+        "repair":                 repair_node,
+        "conflict_resolution":    conflict_resolution_node,
+        "human_review_gate":      human_review_gate_node,
+        "generate_note":          generate_note_node,
+        "package_outputs":        package_outputs_node,
+        "persist_results":        persist_results_node,
+    }
+
+    for name, fn in nodes.items():
+        graph.add_node(name, make_node(fn, ctx))
+
+    # ── Edges: linear pipeline with DB bookends ─────────────────────────────
+    graph.set_entry_point("greeting")
+    graph.add_edge("greeting", "load_patient_context")
+    graph.add_edge("load_patient_context", "ingest")
+    graph.add_edge("ingest", "clean_transcription")
+    graph.add_edge("clean_transcription", "normalize_transcript")
+    graph.add_edge("normalize_transcript", "segment_and_chunk")
+    graph.add_edge("segment_and_chunk", "extract_candidates")
+    graph.add_edge("extract_candidates", "retrieve_evidence")
+    graph.add_edge("retrieve_evidence", "fill_structured_record")
+    graph.add_edge("fill_structured_record", "clinical_suggestions")
+    graph.add_edge("clinical_suggestions", "validate_and_score")
+
+    # ── Conditional edges: validate → repair loop / conflicts / review ──────
+    graph.add_conditional_edges("validate_and_score", _route_after_validate)
+    graph.add_conditional_edges("conflict_resolution", _route_after_conflict)
+
+    graph.add_edge("repair", "validate_and_score")  # loop back
+    graph.add_edge("human_review_gate", "package_outputs")
+    graph.add_edge("generate_note", "package_outputs")
+    graph.add_edge("package_outputs", "persist_results")
+    graph.add_edge("persist_results", END)
+
+    # ── Compile with optional checkpointing + interrupts ────────────────────
+    compile_kwargs: dict = {}
+
+    if checkpoint_path is None:
+        storage_dir = Path(__file__).parent.parent.parent / "storage"
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        checkpoint_path = str(storage_dir / "checkpoints.db")
+
+    try:
+        import sqlite3
+        conn = sqlite3.connect(checkpoint_path, check_same_thread=False)
+        checkpointer = SqliteSaver(conn)
+        compile_kwargs["checkpointer"] = checkpointer
+    except Exception as e:
+        print(f"[WARNING] Could not create checkpointer: {e}")
+
+    if enable_interrupts:
+        compile_kwargs["interrupt_before"] = ["human_review_gate"]
+
+    return graph.compile(**compile_kwargs)

--- a/server/app/agents/state.py
+++ b/server/app/agents/state.py
@@ -1,0 +1,105 @@
+
+from typing import List, Optional, TypedDict, Dict, Any, Literal
+
+
+
+class TranscriptSegment(TypedDict):
+    start: float
+    end: float
+    speaker: Optional[str]
+    raw_text: str
+    cleaned_text: Optional[str]
+    uncertainties: List[str]
+    confidence: Optional[str]
+
+
+class ConversationTurn(TypedDict):
+    timestamp: float
+    segments: List[TranscriptSegment]
+
+
+class DocumentArtifact(TypedDict):
+    document_id: str
+    source_type: Literal["pdf", "image", "text", "unknown"]
+    extracted_text: str
+    tables: List[Dict[str, Any]]
+    metadata: Dict[str, Any]
+
+
+class ChunkArtifact(TypedDict):
+    chunk_id: str
+    source: Literal["transcript", "document"]
+    source_id: str
+    text: str
+    start: Optional[float]
+    end: Optional[float]
+    metadata: Dict[str, Any]
+
+
+class CandidateFact(TypedDict):
+    fact_id: str
+    type: str
+    value: Any
+    provenance: Dict[str, Any]
+    confidence: Optional[float]
+
+
+class EvidenceItem(TypedDict):
+    source_id: str
+    source_type: Literal["transcript", "document"]
+    snippet: str
+    confidence: Optional[float]
+    metadata: Dict[str, Any]
+
+
+class ValidationReport(TypedDict):
+    schema_errors: List[str]
+    missing_fields: List[str]
+    conflicts: List[str]
+    needs_review: bool
+    confidence: Optional[float]
+    details: Dict[str, Any]
+
+
+class ConflictReport(TypedDict):
+    unresolved: bool
+    conflicts: List[str]
+    resolutions: List[str]
+    evidence: Dict[str, Any]
+
+
+class Controls(TypedDict):
+    attempts: Dict[str, int]
+    budget: Dict[str, Any]
+    trace_log: List[Dict[str, Any]]
+
+
+class GraphState(TypedDict):
+    session_id: str
+    patient_id: str
+    doctor_id: str
+
+    conversation_log: List[ConversationTurn]
+    new_segments: List[TranscriptSegment]
+
+    session_summary: Optional[Dict[str, Any]]
+    patient_record_fields: Optional[Dict[str, Any]]
+
+    message: Optional[str]
+    flags: Dict[str, bool]
+
+    # Artifact-driven pipeline additions
+    inputs: Dict[str, Any]
+    documents: List[DocumentArtifact]
+    chunks: List[ChunkArtifact]
+    candidate_facts: List[CandidateFact]
+    evidence_map: Dict[str, List[EvidenceItem]]
+    structured_record: Dict[str, Any]
+    validation_report: Optional[ValidationReport]
+    conflict_report: Optional[ConflictReport]
+    clinical_note: Optional[str]
+    clinical_suggestions: Optional[Dict[str, Any]]  # Clinical decision support suggestions
+    is_new_patient: bool  # Skip DB lookups for brand-new patients
+    controls: Controls
+
+

--- a/server/app/agents/summarizer.py
+++ b/server/app/agents/summarizer.py
@@ -1,0 +1,34 @@
+import os
+from datetime import datetime
+from time import time
+
+from app.models.llm import LLMClient
+from .state import GraphState, TranscriptSegment
+
+def summarize_transcript_node(state: GraphState) -> GraphState:
+    """Summarizes the entire conversation log into a concise session summary."""
+    print("Running Summarization of transcription segments")
+    state = state.copy()
+    
+    if not state["conversation_log"]:
+        state["session_summary"] = "No conversation data available."
+        return state
+    
+    full_transcript = ""
+    for entry in state["conversation_log"]:
+        for seg in entry["segments"]:
+            full_transcript += seg.get("cleaned_text", seg["raw_text"]) + " "
+    
+    prompts = """You are a medical transcription summarization engine.
+
+    Rules:
+    - Summarize the key points of the conversation.
+    - Do not add any new information.
+    - Keep it concise and clinically relevant.
+    Return a single string summary."""
+
+    llm = LLMClient()
+    response = llm.generate_response(prompts + f"\nFull Transcript:\n{full_transcript}\n")
+
+    state["session_summary"] = response.strip()
+    return state

--- a/server/app/agents/validation_contracts.py
+++ b/server/app/agents/validation_contracts.py
@@ -1,0 +1,106 @@
+from typing import Any, Dict
+
+# Deterministic validation contract for structured clinical records.
+CONTRACT: Dict[str, Any] = {
+    "fields": {
+        "patient": {
+            "type": dict,
+            "required": True,
+            "schema": {
+                "name": {"type": str, "required": True, "non_empty": True},
+                "dob": {"type": str, "required": True, "iso_format": True},
+                "age": {"type": int, "required": False, "min_confidence": 0.9},
+                "sex": {"type": str, "required": False},
+                "mrn": {"type": str, "required": False},
+            },
+        },
+        "visit": {
+            "type": dict,
+            "required": True,
+            "schema": {
+                "date": {"type": str, "required": True, "iso_format": True},
+                "type": {"type": str, "required": False},
+                "location": {"type": str, "required": False},
+                "provider": {"type": str, "required": False},
+            },
+        },
+        "diagnoses": {
+            "type": list,
+            "required": False,
+            "item_schema": {
+                "schema": {
+                    "code": {"type": str, "required": True, "non_empty": True},
+                    "description": {"type": str, "required": False},
+                    "confidence": {"type": float, "required": False},
+                }
+            },
+        },
+        "medications": {
+            "type": list,
+            "required": False,
+            "item_schema": {
+                "schema": {
+                    "name": {"type": str, "required": True, "non_empty": True},
+                    "dose": {"type": str, "required": False},
+                    "route": {"type": str, "required": False},
+                    "frequency": {"type": str, "required": False},
+                    "start_date": {"type": str, "required": False, "iso_format": True},
+                    "confidence": {"type": float, "required": False},
+                }
+            },
+        },
+        "allergies": {
+            "type": list,
+            "required": False,
+            "item_schema": {
+                "schema": {
+                    "substance": {"type": str, "required": True, "non_empty": True},
+                    "reaction": {"type": str, "required": False},
+                    "severity": {"type": str, "required": False},
+                }
+            },
+        },
+        "problems": {
+            "type": list,
+            "required": False,
+            "item_schema": {
+                "schema": {
+                    "name": {"type": str, "required": True, "non_empty": True},
+                    "status": {"type": str, "required": False},
+                }
+            },
+        },
+        "labs": {
+            "type": list,
+            "required": False,
+            "item_schema": {
+                "schema": {
+                    "test": {"type": str, "required": True, "non_empty": True},
+                    "value": {"type": str, "required": False},
+                    "unit": {"type": str, "required": False},
+                    "date": {"type": str, "required": False, "iso_format": True},
+                }
+            },
+        },
+        "procedures": {
+            "type": list,
+            "required": False,
+            "item_schema": {
+                "schema": {
+                    "name": {"type": str, "required": True, "non_empty": True},
+                    "date": {"type": str, "required": False, "iso_format": True},
+                }
+            },
+        },
+        "notes": {
+            "type": dict,
+            "required": False,
+            "schema": {
+                "subjective": {"type": str, "required": False},
+                "objective": {"type": str, "required": False},
+                "assessment": {"type": str, "required": False},
+                "plan": {"type": str, "required": False},
+            },
+        },
+    }
+}


### PR DESCRIPTION
…AgentContext

- GraphState TypedDict: full pipeline state contract (transcript segments, document artifacts, chunks, candidate facts, evidence, structured record, validation/conflict reports, SOAP note, controls, audit trail)
- AgentContext: dependency-injected service container passed to every node
- ValidationContracts: Pydantic schemas enforced at each pipeline boundary
- build_graph(): wires all 17 nodes, conditional edges for repair loop / conflict resolution / human review gate, SQLite checkpoint for resumability
- Routing helpers: _route_after_validate, _route_after_conflict
- greeting_node: seeds initial state with personalised doctor welcome
- Agents.md: pipeline design notes and node responsibility matrix