### PR TITLE
feat(pipeline/ingestion): add ingestion phase nodes  ingest, clean, n…

### DIFF
--- a/server/app/agents/nodes/__init__.py
+++ b/server/app/agents/nodes/__init__.py
@@ -1,0 +1,38 @@
+"""
+Agent nodes — one file per pipeline step.
+
+Each node is a pure function: ``(state[, ctx]) -> state``.
+Nodes that need external services accept an ``AgentContext`` as second arg.
+"""
+
+from .ingest import ingest_transcript_node
+from .clean import clean_transcription_node
+from .normalize import normalize_transcript_node
+from .segment import segment_and_chunk_node
+from .extract import extract_candidates_node
+from .evidence import retrieve_evidence_node
+from .fill_record import fill_structured_record_node
+from .clinical_suggestions import clinical_suggestions_node
+from .validate import validate_and_score_node
+from .repair import repair_node
+from .conflicts import conflict_resolution_node
+from .review_gate import human_review_gate_node
+from .generate_note import generate_note_node
+from .package import package_outputs_node
+
+__all__ = [
+    "ingest_transcript_node",
+    "clean_transcription_node",
+    "normalize_transcript_node",
+    "segment_and_chunk_node",
+    "extract_candidates_node",
+    "retrieve_evidence_node",
+    "fill_structured_record_node",
+    "clinical_suggestions_node",
+    "validate_and_score_node",
+    "repair_node",
+    "conflict_resolution_node",
+    "human_review_gate_node",
+    "generate_note_node",
+    "package_outputs_node",
+]

--- a/server/app/agents/nodes/clean.py
+++ b/server/app/agents/nodes/clean.py
@@ -1,0 +1,172 @@
+import json
+import logging
+import os
+from ..state import GraphState, TranscriptSegment
+from ...models.llm import LLMClient
+
+logger = logging.getLogger(__name__)
+
+# ── Prompts ────────────────────────────────────────────────────────────────
+
+_SINGLE_PROMPT = """You are a medical transcription cleaning engine.
+
+Rules:
+- Ensure clarity and readability.
+- Do not change clinical meaning.
+- Do not infer diagnoses or facts.
+- Preserve original phrasing where possible.
+- Fix grammar, punctuation, and formatting only.
+- If a phrase is unclear, mark it as uncertain.
+
+Return JSON:
+{
+    "cleaned_text": string,
+    "uncertainties": string[]
+}"""
+
+_BATCH_PROMPT = """You are a medical transcription cleaning engine.
+
+Rules:
+- Ensure clarity and readability.
+- Do not change clinical meaning.
+- Do not infer diagnoses or facts.
+- Preserve original phrasing where possible.
+- Fix grammar, punctuation, and formatting only.
+- If a phrase is unclear, mark it as uncertain.
+
+You will receive multiple segments. Clean each one independently.
+Return a JSON object with a "segments" array, one entry per input segment,
+in the SAME order:
+{
+    "segments": [
+        {"cleaned_text": string, "uncertainties": string[]},
+        ...
+    ]
+}"""
+
+# Maximum segments per single batched LLM call
+_BATCH_SIZE = 5
+
+
+def clean_transcription_node(state: GraphState) -> GraphState:
+    """
+    Clean transcription segments using the LLM.
+
+    Batches up to 5 segments per LLM call to reduce latency.
+    Falls back to single-segment calls if batch parsing fails.
+    """
+    logger.info("Running Cleaning transcription segments")
+
+    state = state.copy()
+
+    if not state["conversation_log"]:
+        return state
+
+    latest_segment = state["conversation_log"][-1]
+    segments = latest_segment["segments"]
+
+    if not segments:
+        return state
+
+    # ── Try batched cleaning first ──────────────────────────────────────────
+    cleaned_segments = _clean_batch(segments)
+
+    state["conversation_log"][-1] = {
+        "timestamp": latest_segment["timestamp"],
+        "segments": cleaned_segments,
+    }
+
+    # Log to agent actions file
+    log_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "logs")
+    os.makedirs(log_dir, exist_ok=True)
+    with open(os.path.join(log_dir, "agent_actions.log"), "a", encoding="utf-8") as f:
+        f.write(
+            f"\n[Clean Transcription Node] Cleaned {len(cleaned_segments)} segments "
+            f"at timestamp {latest_segment['timestamp']}\n"
+        )
+        f.write(f"Prior Segments: {latest_segment['segments']}\n")
+        f.write(f"Cleaned Segments: {cleaned_segments}\n")
+
+    return state
+
+
+# ── Internal helpers ────────────────────────────────────────────────────────
+
+def _clean_batch(segments: list) -> list:
+    """
+    Clean segments in batches of up to _BATCH_SIZE per LLM call.
+
+    Falls back to one-by-one cleaning if a batch fails to parse.
+    """
+    cleaned: list = []
+
+    for i in range(0, len(segments), _BATCH_SIZE):
+        batch = segments[i : i + _BATCH_SIZE]
+
+        if len(batch) == 1:
+            # Single segment — use the simpler prompt directly
+            cleaned.append(_clean_single(batch[0]))
+            continue
+
+        # Build numbered input for the batch
+        numbered_input = "\n".join(
+            f"Segment {idx + 1}:\n{seg['raw_text']}"
+            for idx, seg in enumerate(batch)
+        )
+
+        try:
+            llm = LLMClient()
+            response = llm.generate_response(
+                _BATCH_PROMPT + f"\n\n{numbered_input}\n"
+            )
+            logger.debug("Batch LLM response: %s", response)
+
+            parsed = json.loads(response)
+            results = parsed.get("segments", [])
+
+            if len(results) == len(batch):
+                for seg, result in zip(batch, results):
+                    cleaned.append({
+                        **seg,
+                        "cleaned_text": result.get("cleaned_text", seg["raw_text"]),
+                        "uncertainties": result.get("uncertainties", []),
+                    })
+                continue  # success — move to next batch
+
+            # Length mismatch — fall through to single
+            logger.warning(
+                "Batch LLM returned %d results for %d segments — falling back to single",
+                len(results), len(batch),
+            )
+        except (json.JSONDecodeError, Exception) as e:
+            logger.warning("Batch clean failed (%s) — falling back to single-segment", e)
+
+        # Fallback: process each segment individually
+        for seg in batch:
+            cleaned.append(_clean_single(seg))
+
+    return cleaned
+
+
+def _clean_single(seg: dict) -> dict:
+    """Clean a single segment via one LLM call."""
+    try:
+        llm = LLMClient()
+        response = llm.generate_response(
+            _SINGLE_PROMPT + f"\nTranscription Segment:\n{seg['raw_text']}\n"
+        )
+        logger.debug("LLM returned response: %s", response)
+        result = json.loads(response)
+    except (json.JSONDecodeError, Exception):
+        result = {
+            "cleaned_text": seg["raw_text"],
+            "uncertainties": ["LLM response could not be parsed as JSON."],
+        }
+
+    return {
+        **seg,
+        "cleaned_text": result.get("cleaned_text", seg["raw_text"]),
+        "uncertainties": result.get("uncertainties", []),
+    }
+
+

--- a/server/app/agents/nodes/ingest.py
+++ b/server/app/agents/nodes/ingest.py
@@ -1,0 +1,105 @@
+import os
+import uuid
+from datetime import datetime
+from time import time
+from ..state import GraphState, TranscriptSegment, DocumentArtifact, ChunkArtifact
+
+
+def ingest_transcript_node(state: GraphState) -> GraphState:
+    """Ingests raw transcript segments into the conversation log if any are present"""
+    print("Running Ingest transcription segments")
+    state = state.copy()
+    new_segments = state.pop("new_segments", None)
+
+    if not new_segments:
+        return state
+    
+    timestamp = time()
+
+    state.setdefault("conversation_log", []).append({
+        "timestamp": timestamp,
+        "segments": new_segments,
+    })
+
+    _log_segments_to_file(state["session_id"], new_segments, timestamp)
+
+    # Log to agent actions file
+    log_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "logs")
+    os.makedirs(log_dir, exist_ok=True)
+    with open(os.path.join(log_dir, "agent_actions.log"), "a", encoding="utf-8") as f:
+        f.write(f"\n[Ingest Node] Ingested {len(new_segments)} segments at timestamp {timestamp}\n")
+        f.write(f"Segments: {new_segments}\n")
+
+    # ── Document ingestion branch ───────────────────────────────────────
+    # If documents have been attached via the OCR pipeline, convert each
+    # DocumentArtifact into ChunkArtifact(s) with source="document" so the
+    # downstream extract / evidence / fill_record nodes can consume them.
+    documents: list = state.get("documents", [])
+    if documents:
+        chunks = state.setdefault("chunks", [])
+        candidate_facts = state.setdefault("candidate_facts", [])
+
+        for doc in documents:
+            doc_text = doc.get("extracted_text", "")
+            doc_id = doc.get("document_id", str(uuid.uuid4()))
+            metadata = doc.get("metadata", {})
+
+            if not doc_text:
+                continue
+
+            # Split document text into ~500-char chunks for parity with
+            # transcript chunks produced by the segment node.
+            for i, start in enumerate(range(0, len(doc_text), 500)):
+                chunk_text = doc_text[start : start + 500]
+                chunk_id = f"doc_{doc_id}_{i}"
+                chunks.append({
+                    "chunk_id": chunk_id,
+                    "source": "document",
+                    "source_id": doc_id,
+                    "text": chunk_text,
+                    "start": None,
+                    "end": None,
+                    "metadata": {
+                        "original_filename": metadata.get("original_filename", ""),
+                        "document_type": metadata.get("document_type", "unknown"),
+                        "page_count": metadata.get("page_count", 0),
+                        "chunk_index": i,
+                    },
+                })
+
+            print(f"[Ingest] Ingested document {doc_id}: "
+                  f"{len(doc_text)} chars → {len(range(0, len(doc_text), 500))} chunks")
+
+        # Log document ingestion
+        with open(os.path.join(log_dir, "agent_actions.log"), "a", encoding="utf-8") as f:
+            f.write(f"[Ingest Node] Ingested {len(documents)} documents → {len(chunks)} total chunks\n")
+
+    return state
+
+def _log_segments_to_file(session_id: str, segments: list[TranscriptSegment], timestamp: float):
+    """Helper to log ingested segments to a file for auditing/debugging."""
+    print(f"Logging segments to file for session {session_id} at {datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')}")
+
+    # Use path relative to server directory
+    log_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "logs")
+    os.makedirs(log_dir, exist_ok=True)
+    filename = os.path.join(log_dir, f"session_{session_id}_transcript.log")
+    
+    print(f"Writing to: {filename}")
+    
+    with open(filename, "a", encoding="utf-8") as f:
+        dt = datetime.fromtimestamp(timestamp)
+        f.write(f"\n{'='*60}\n")
+        f.write(f"Timestamp: {dt.strftime('%Y-%m-%d %H:%M:%S')}\n")
+        f.write(f"{'='*60}\n\n")
+    
+        for seg in segments:
+            f.write(f"[{seg['start']:.2f}s - {seg['end']:.2f}s] ")
+            if seg.get('speaker'):
+                f.write(f"{seg['speaker']}: ")
+            f.write(f"{seg['raw_text']}")
+            if seg.get('confidence'):
+                f.write(f" (confidence: {seg['confidence']})")
+            f.write("\n")
+
+    

--- a/server/app/agents/nodes/load_patient_context.py
+++ b/server/app/agents/nodes/load_patient_context.py
@@ -1,0 +1,136 @@
+"""
+Load Patient Context Node — Hydrates pipeline state from database.
+
+Runs immediately after greeting_node to populate patient_record_fields
+with the patient's prior clinical history from:
+  1. Patient demographics (patients table)
+  2. Most recent finalized MedicalRecord (medical_records table)
+  3. Prior clinical facts via embedding search (clinical_embeddings table)
+
+If no DB services are available, the pipeline degrades gracefully
+and proceeds with empty patient context (same as before this node existed).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from ..config import AgentContext
+from ..state import GraphState
+
+logger = logging.getLogger(__name__)
+
+
+def load_patient_context_node(state: GraphState, ctx: AgentContext) -> GraphState:
+    """
+    Hydrate patient_record_fields from the database.
+
+    Populates:
+      - state["patient_record_fields"]["demographics"]: name, dob, age, sex, mrn
+      - state["patient_record_fields"]["prior_record"]: last finalized structured_data
+      - state["patient_record_fields"]["prior_facts"]: grouped clinical facts from embeddings
+      - state["patient_record_fields"]["visit_count"]: total prior visits
+
+    Falls back to empty context if DB is unavailable.
+    """
+    state = {**state}
+    patient_id = state.get("patient_id", "")
+    controls = state.get("controls", {"attempts": {}, "budget": {}, "trace_log": []})
+
+    patient_context: Dict[str, Any] = {
+        "demographics": {},
+        "prior_record": {},
+        "prior_facts": {},
+        "visit_count": 0,
+        "loaded_from_db": False,
+    }
+
+    if not patient_id:
+        logger.warning("[LoadPatientContext] No patient_id in state — skipping DB lookup")
+        state["patient_record_fields"] = patient_context
+        _trace(controls, "skipped", "no_patient_id")
+        return state
+
+    # ── Fast path: skip DB lookups for new patients ─────────────────────────
+    if state.get("is_new_patient"):
+        logger.info("[LoadPatientContext] is_new_patient=True — skipping DB lookups")
+        state["patient_record_fields"] = patient_context
+        _trace(controls, "skipped", "new_patient")
+        return state
+
+    # ── 1. Load demographics from Patient table ─────────────────────────────
+    if ctx.patient_repo is not None:
+        try:
+            patient = ctx.patient_repo.get_by_id(patient_id)
+            if patient:
+                patient_context["demographics"] = {
+                    "full_name": patient.full_name,
+                    "dob": patient.dob.isoformat() if patient.dob else None,
+                    "age": patient.age,
+                    "sex": patient.sex,
+                    "mrn": patient.mrn,
+                }
+                logger.info(f"[LoadPatientContext] Loaded demographics for patient {patient_id}")
+            else:
+                logger.info(f"[LoadPatientContext] Patient {patient_id} not found in DB (new patient)")
+        except Exception as e:
+            logger.error(f"[LoadPatientContext] Failed to load demographics: {e}")
+
+    # ── 2. Load most recent finalized MedicalRecord ─────────────────────────
+    if ctx.record_repo is not None:
+        try:
+            records = ctx.record_repo.get_for_patient(patient_id, limit=1)
+            if records:
+                latest = records[0]
+                patient_context["prior_record"] = latest.structured_data or {}
+                # Use COUNT query instead of fetching all records
+                patient_context["visit_count"] = ctx.record_repo.count_for_patient(patient_id)
+                logger.info(
+                    f"[LoadPatientContext] Loaded prior record (version={latest.version}, "
+                    f"is_final={latest.is_final})"
+                )
+        except Exception as e:
+            logger.error(f"[LoadPatientContext] Failed to load prior records: {e}")
+
+    # ── 3. Load clinical fact embeddings (grouped by type) ──────────────────
+    if ctx.embedding_service is not None:
+        try:
+            grouped_facts = ctx.embedding_service.get_all_patient_facts(
+                patient_id=patient_id,
+                only_final=True,
+            )
+            patient_context["prior_facts"] = grouped_facts
+            total_facts = sum(len(v) for v in grouped_facts.values())
+            logger.info(
+                f"[LoadPatientContext] Loaded {total_facts} prior facts across "
+                f"{len(grouped_facts)} categories"
+            )
+        except Exception as e:
+            logger.error(f"[LoadPatientContext] Failed to load clinical embeddings: {e}")
+
+    patient_context["loaded_from_db"] = bool(
+        patient_context["demographics"] or patient_context["prior_record"] or patient_context["prior_facts"]
+    )
+
+    state["patient_record_fields"] = patient_context
+    _trace(
+        controls,
+        "loaded" if patient_context["loaded_from_db"] else "empty",
+        f"demographics={bool(patient_context['demographics'])}, "
+        f"prior_record={bool(patient_context['prior_record'])}, "
+        f"prior_facts={sum(len(v) for v in patient_context['prior_facts'].values())} facts",
+    )
+
+    return state
+
+
+def _trace(controls: Dict[str, Any], action: str, detail: str) -> None:
+    """Append a trace log entry."""
+    controls.setdefault("trace_log", []).append({
+        "node": "load_patient_context",
+        "action": action,
+        "detail": detail,
+        "timestamp": datetime.now().isoformat(),
+    })

--- a/server/app/agents/nodes/normalize.py
+++ b/server/app/agents/nodes/normalize.py
@@ -1,0 +1,264 @@
+from ..state import GraphState, TranscriptSegment, ConversationTurn
+from datetime import datetime, timedelta
+from typing import List
+import re
+
+
+# Common filler words and disfluencies to remove
+FILLER_WORDS = {
+    "um", "uh", "ah", "er", "hmm", "mhm", "uhm", "like", "you know",
+    "i mean", "sort of", "kind of", "basically", "actually", "literally"
+}
+
+# Speaker label normalization mapping
+SPEAKER_MAPPING = {
+    # Doctor variants
+    "dr": "Doctor",
+    "doc": "Doctor",
+    "doctor": "Doctor",
+    "physician": "Doctor",
+    "md": "Doctor",
+    "provider": "Doctor",
+    # Patient variants
+    "pt": "Patient",
+    "patient": "Patient",
+    "client": "Patient",
+    # Nurse variants
+    "rn": "Nurse",
+    "nurse": "Nurse",
+    "lpn": "Nurse",
+    "np": "Nurse",
+    "nurse practitioner": "Nurse",
+    # Assistant variants
+    "ma": "Medical Assistant",
+    "medical assistant": "Medical Assistant",
+    "assistant": "Medical Assistant",
+    "aide": "Medical Assistant",
+    # Other
+    "family": "Family Member",
+    "relative": "Family Member",
+    "visitor": "Family Member",
+    "unknown": "Unknown",
+    "unidentified": "Unknown"
+}
+
+
+def normalize_timestamp(timestamp_seconds: float) -> str:
+    """
+    Convert timestamp in seconds to ISO-8601 format.
+    If already an ISO-8601 string, pass through unchanged.
+    Returns None for None input.
+
+    Args:
+        timestamp_seconds: Timestamp in seconds from start, or ISO string
+
+    Returns:
+        ISO-8601 formatted timestamp string, or None
+    """
+    if timestamp_seconds is None:
+        return None
+
+    # If already an ISO string, pass through
+    if isinstance(timestamp_seconds, str):
+        try:
+            datetime.fromisoformat(timestamp_seconds)
+            return timestamp_seconds
+        except ValueError:
+            pass
+        # Try to parse as a numeric string
+        try:
+            timestamp_seconds = float(timestamp_seconds)
+        except (ValueError, TypeError):
+            return timestamp_seconds
+
+    # Use a reference date (session start would be better in production)
+    reference_time = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    actual_time = reference_time + timedelta(seconds=timestamp_seconds)
+    return actual_time.isoformat()
+
+
+def standardize_speaker_label(speaker: str) -> str:
+    """
+    Standardize speaker labels to consistent format.
+
+    Args:
+        speaker: Raw speaker label
+
+    Returns:
+        Standardized speaker label
+    """
+    if not speaker:
+        return "Unknown"
+
+    # Normalize to lowercase for matching
+    speaker_lower = speaker.lower().strip()
+
+    # Check mapping
+    if speaker_lower in SPEAKER_MAPPING:
+        return SPEAKER_MAPPING[speaker_lower]
+
+    # If no match, capitalize first letter of each word
+    return speaker.title()
+
+
+def remove_filler_words(text: str) -> str:
+    """
+    Remove common filler words and disfluencies from text.
+
+    Args:
+        text: Input text with fillers
+
+    Returns:
+        Cleaned text without fillers
+    """
+    if not text:
+        return text
+
+    # Convert to lowercase for matching, but preserve original case
+    words = text.split()
+    cleaned_words = []
+
+    i = 0
+    while i < len(words):
+        word = words[i]
+        word_lower = word.lower().strip('.,!?;:')
+
+        # Check for multi-word fillers
+        if i < len(words) - 1:
+            two_word = f"{word_lower} {words[i+1].lower().strip('.,!?;:')}"
+            if two_word in FILLER_WORDS:
+                i += 2
+                continue
+
+        # Check single word fillers
+        if word_lower not in FILLER_WORDS:
+            cleaned_words.append(word)
+
+        i += 1
+
+    # Join and clean up extra spaces
+    cleaned = ' '.join(cleaned_words)
+    cleaned = re.sub(r'\s+', ' ', cleaned)  # Remove multiple spaces
+    cleaned = re.sub(r'\s+([.,!?;:])', r'\1', cleaned)  # Fix punctuation spacing
+
+    return cleaned.strip()
+
+
+def merge_adjacent_segments(segments: List[TranscriptSegment]) -> List[TranscriptSegment]:
+    """
+    Merge adjacent segments from the same speaker.
+
+    Args:
+        segments: List of transcript segments
+
+    Returns:
+        List of merged segments
+    """
+    if not segments:
+        return segments
+
+    merged = []
+    current_segment = None
+
+    for segment in segments:
+        if current_segment is None:
+            # First segment
+            current_segment = segment.copy()
+        elif (segment.get('speaker') == current_segment.get('speaker') and
+              segment.get('speaker') is not None):
+            # Same speaker - merge
+            current_segment['end'] = segment['end']
+            current_segment['raw_text'] += ' ' + segment['raw_text']
+
+            # Merge cleaned text if available
+            if current_segment.get('cleaned_text') and segment.get('cleaned_text'):
+                current_segment['cleaned_text'] += ' ' + segment['cleaned_text']
+
+            # Merge uncertainties
+            if segment.get('uncertainties'):
+                current_uncertainties = current_segment.get('uncertainties', [])
+                current_segment['uncertainties'] = current_uncertainties + segment['uncertainties']
+        else:
+            # Different speaker - save current and start new
+            merged.append(current_segment)
+            current_segment = segment.copy()
+
+    # Don't forget the last segment
+    if current_segment is not None:
+        merged.append(current_segment)
+
+    return merged
+
+
+def normalize_transcript_node(state: GraphState) -> GraphState:
+    """
+    Normalize transcript segments:
+    - Convert timestamps to ISO-8601 format
+    - Standardize speaker labels (Doctor, Patient, Nurse, etc.)
+    - Merge adjacent segments from the same speaker
+    - Remove filler words and disfluencies
+
+    Args:
+        state: Current graph state with new_segments
+
+    Returns:
+        Updated state with normalized conversation_log
+    """
+    new_segments = state.get('new_segments', [])
+
+    if not new_segments:
+        # No new segments to process
+        state['controls']['trace_log'].append({
+            'node': 'normalize_transcript',
+            'action': 'skipped',
+            'reason': 'no_new_segments',
+            'timestamp': datetime.now().isoformat()
+        })
+        return state
+
+    # Step 1: Normalize each segment
+    normalized_segments = []
+    for segment in new_segments:
+        normalized_seg = segment.copy()
+
+        # Standardize speaker label
+        if segment.get('speaker'):
+            normalized_seg['speaker'] = standardize_speaker_label(segment['speaker'])
+
+        # Clean the text (remove fillers)
+        if segment.get('raw_text'):
+            cleaned = remove_filler_words(segment['raw_text'])
+            normalized_seg['cleaned_text'] = cleaned
+
+        normalized_segments.append(normalized_seg)
+
+    # Step 2: Merge adjacent segments from same speaker
+    merged_segments = merge_adjacent_segments(normalized_segments)
+
+    # Step 3: Create conversation turns with ISO-8601 timestamps
+    conversation_log = state.get('conversation_log', [])
+
+    for segment in merged_segments:
+        turn: ConversationTurn = {
+            'timestamp': segment['start'],  # Keep numeric for now, can convert in presentation layer
+            'segments': [segment]
+        }
+        conversation_log.append(turn)
+
+    # Update state
+    state['conversation_log'] = conversation_log
+
+    # Clear new_segments since they've been processed
+    state['new_segments'] = []
+
+    # Log the operation
+    state['controls']['trace_log'].append({
+        'node': 'normalize_transcript',
+        'action': 'normalized',
+        'input_segments': len(new_segments),
+        'output_segments': len(merged_segments),
+        'merged_count': len(new_segments) - len(merged_segments),
+        'timestamp': datetime.now().isoformat()
+    })
+
+    return state

--- a/server/app/agents/nodes/segment.py
+++ b/server/app/agents/nodes/segment.py
@@ -1,0 +1,206 @@
+from ..state import GraphState, ChunkArtifact, ConversationTurn, DocumentArtifact
+from datetime import datetime
+from typing import List
+import uuid
+
+
+# Chunk configuration
+CHUNK_SIZE = 500  # characters (roughly 100-125 tokens)
+CHUNK_OVERLAP = 50  # characters
+
+
+def create_chunk_id() -> str:
+    """Generate unique chunk ID."""
+    return f"chunk_{uuid.uuid4().hex[:12]}"
+
+
+def recursive_text_splitter(text: str, chunk_size: int, overlap: int) -> List[str]:
+    """
+    Recursively split text into chunks, attempting to preserve sentence boundaries.
+
+    Args:
+        text: Input text to chunk
+        chunk_size: Maximum chunk size in characters
+        overlap: Number of overlapping characters between chunks
+
+    Returns:
+        List of text chunks
+    """
+    if len(text) <= chunk_size:
+        return [text]
+
+    chunks = []
+    start = 0
+
+    # Separators to try in order (preserve semantic boundaries)
+    separators = ['\n\n', '\n', '. ', '? ', '! ', '; ', ', ', ' ']
+
+    while start < len(text):
+        end = start + chunk_size
+
+        if end >= len(text):
+            # Last chunk
+            chunks.append(text[start:].strip())
+            break
+
+        # Try to find a good split point using separators
+        split_point = None
+        for separator in separators:
+            # Look for separator within the chunk
+            search_end = min(end, len(text))
+            last_sep = text[start:search_end].rfind(separator)
+
+            if last_sep != -1 and last_sep > chunk_size // 2:  # At least halfway through
+                split_point = start + last_sep + len(separator)
+                break
+
+        if split_point is None:
+            # No good separator found, split at chunk_size
+            split_point = end
+
+        # Extract chunk
+        chunk_text = text[start:split_point].strip()
+        if chunk_text:
+            chunks.append(chunk_text)
+
+        # Move start forward with overlap
+        start = split_point - overlap
+
+    return chunks
+
+
+def chunk_conversation_log(conversation_log: List[ConversationTurn]) -> List[ChunkArtifact]:
+    """
+    Create semantic chunks from conversation log.
+
+    Args:
+        conversation_log: List of conversation turns
+
+    Returns:
+        List of chunk artifacts
+    """
+    chunks: List[ChunkArtifact] = []
+
+    for turn in conversation_log:
+        timestamp = turn['timestamp']
+        segments = turn['segments']
+
+        # Combine all segments in this turn
+        for segment in segments:
+            text = segment.get('cleaned_text') or segment.get('raw_text', '')
+            speaker = segment.get('speaker', 'Unknown')
+
+            if not text.strip():
+                continue
+
+            # Split text into chunks
+            text_chunks = recursive_text_splitter(text, CHUNK_SIZE, CHUNK_OVERLAP)
+
+            for chunk_text in text_chunks:
+                chunk: ChunkArtifact = {
+                    'chunk_id': create_chunk_id(),
+                    'source': 'transcript',
+                    'source_id': f"turn_{timestamp}_{speaker}",
+                    'text': chunk_text,
+                    'start': segment.get('start'),
+                    'end': segment.get('end'),
+                    'metadata': {
+                        'speaker': speaker,
+                        'timestamp': timestamp,
+                        'confidence': segment.get('confidence'),
+                        'uncertainties': segment.get('uncertainties', [])
+                    }
+                }
+                chunks.append(chunk)
+
+    return chunks
+
+
+def chunk_documents(documents: List[DocumentArtifact]) -> List[ChunkArtifact]:
+    """
+    Create semantic chunks from document artifacts.
+
+    Args:
+        documents: List of document artifacts
+
+    Returns:
+        List of chunk artifacts
+    """
+    chunks: List[ChunkArtifact] = []
+
+    for doc in documents:
+        extracted_text = doc.get('extracted_text', '')
+
+        if not extracted_text.strip():
+            continue
+
+        # Split text into chunks
+        text_chunks = recursive_text_splitter(extracted_text, CHUNK_SIZE, CHUNK_OVERLAP)
+
+        for idx, chunk_text in enumerate(text_chunks):
+            chunk: ChunkArtifact = {
+                'chunk_id': create_chunk_id(),
+                'source': 'document',
+                'source_id': doc['document_id'],
+                'text': chunk_text,
+                'start': None,
+                'end': None,
+                'metadata': {
+                    'document_id': doc['document_id'],
+                    'source_type': doc['source_type'],
+                    'chunk_index': idx,
+                    'total_chunks': len(text_chunks),
+                    'has_tables': len(doc.get('tables', [])) > 0,
+                    'original_metadata': doc.get('metadata', {})
+                }
+            }
+            chunks.append(chunk)
+
+    return chunks
+
+
+def segment_and_chunk_node(state: GraphState) -> GraphState:
+    """
+    Create semantic chunks from transcript and document artifacts.
+
+    Uses recursive character text splitting with:
+    - Chunk size: 500 characters (~100-125 tokens)
+    - Overlap: 50 characters
+    - Preserves conversation context boundaries
+    - Tags chunks with speaker and timestamp metadata
+
+    Args:
+        state: Current graph state
+
+    Returns:
+        Updated state with populated chunks
+    """
+    conversation_log = state.get('conversation_log', [])
+    documents = state.get('documents', [])
+
+    all_chunks: List[ChunkArtifact] = []
+
+    # Process conversation log
+    if conversation_log:
+        transcript_chunks = chunk_conversation_log(conversation_log)
+        all_chunks.extend(transcript_chunks)
+
+    # Process documents
+    if documents:
+        document_chunks = chunk_documents(documents)
+        all_chunks.extend(document_chunks)
+
+    # Update state
+    state['chunks'] = all_chunks
+
+    # Log the operation
+    state['controls']['trace_log'].append({
+        'node': 'segment_and_chunk',
+        'action': 'chunked',
+        'transcript_chunks': len([c for c in all_chunks if c['source'] == 'transcript']),
+        'document_chunks': len([c for c in all_chunks if c['source'] == 'document']),
+        'total_chunks': len(all_chunks),
+        'timestamp': datetime.now().isoformat()
+    })
+
+    return state


### PR DESCRIPTION
…ormalize, segment

- load_patient_context: fetches stored patient history and active meds from DB, seeds GraphState before transcript processing begins
- ingest: loads raw TranscriptSegments and DocumentArtifacts into conversation_log; writes segment log file for audit trail
- clean: removes filler words, disfluencies, and low-confidence fragments; preserves speaker attribution and timing metadata
- normalize: expands medical abbreviations (e.g. HTNhypertension), standardises drug names to RxNorm preferred terms, resolves synonyms
- segment_and_chunk: splits conversation into clinically coherent topic chunks (ChunkArtifacts) using sliding-window overlap for context continuity