### PR TITLE
feat(pipeline/extraction): add extraction phase nodes  extract, evide…

### DIFF
--- a/server/app/agents/nodes/evidence.py
+++ b/server/app/agents/nodes/evidence.py
@@ -1,0 +1,370 @@
+"""
+Retrieve Evidence Node — Layer 2 evidence retrieval.
+
+Supports two modes:
+  1. pgvector cosine search (preferred): O(log n) via embedding_service
+  2. SequenceMatcher fuzzy matching (fallback): O(n*m), no DB required
+
+The node automatically selects pgvector when an EmbeddingService is available
+in the AgentContext, falling back to SequenceMatcher otherwise.
+"""
+
+import logging
+from ..config import AgentContext
+from ..state import GraphState, CandidateFact, ChunkArtifact, EvidenceItem
+from datetime import datetime
+from typing import List, Dict, Optional
+from difflib import SequenceMatcher
+
+logger = logging.getLogger(__name__)
+
+
+# Fuzzy matching threshold
+FUZZY_MATCH_THRESHOLD = 0.6  # 60% similarity
+
+
+def normalize_text_for_matching(text: str) -> str:
+    """
+    Normalize text for fuzzy matching.
+
+    Args:
+        text: Input text
+
+    Returns:
+        Normalized text
+    """
+    # Convert to lowercase, remove extra spaces
+    normalized = text.lower().strip()
+    normalized = ' '.join(normalized.split())
+    return normalized
+
+
+def fuzzy_similarity(text1: str, text2: str) -> float:
+    """
+    Calculate fuzzy similarity between two text strings using SequenceMatcher.
+
+    Args:
+        text1: First text
+        text2: Second text
+
+    Returns:
+        Similarity score (0.0 to 1.0)
+    """
+    norm_text1 = normalize_text_for_matching(text1)
+    norm_text2 = normalize_text_for_matching(text2)
+
+    return SequenceMatcher(None, norm_text1, norm_text2).ratio()
+
+
+def fact_to_search_string(fact: CandidateFact) -> str:
+    """
+    Convert a candidate fact to a search string.
+
+    Args:
+        fact: Candidate fact
+
+    Returns:
+        Search string
+    """
+    fact_type = fact.get('type', '')
+    fact_value = fact.get('value', '')
+
+    # Convert value to string
+    if isinstance(fact_value, dict):
+        # Extract meaningful fields from dict
+        value_parts = []
+        for key, val in fact_value.items():
+            if val:
+                value_parts.append(f"{key}: {val}")
+        value_str = ', '.join(value_parts)
+    elif isinstance(fact_value, list):
+        value_str = ', '.join(str(v) for v in fact_value)
+    else:
+        value_str = str(fact_value)
+
+    # Combine type and value
+    search_string = f"{fact_type} {value_str}"
+    return search_string
+
+
+def find_matching_chunks(
+    fact: CandidateFact,
+    chunks: List[ChunkArtifact],
+    threshold: float = FUZZY_MATCH_THRESHOLD
+) -> List[tuple]:
+    """
+    Find chunks that match a candidate fact using fuzzy matching.
+
+    Args:
+        fact: Candidate fact
+        chunks: List of chunk artifacts
+        threshold: Minimum similarity threshold
+
+    Returns:
+        List of (chunk, similarity_score) tuples, sorted by score
+    """
+    search_string = fact_to_search_string(fact)
+    matches = []
+
+    for chunk in chunks:
+        chunk_text = chunk.get('text', '')
+
+        if not chunk_text.strip():
+            continue
+
+        # Calculate similarity
+        similarity = fuzzy_similarity(search_string, chunk_text)
+
+        if similarity >= threshold:
+            matches.append((chunk, similarity))
+
+        # Also check for exact substring match (case-insensitive)
+        if search_string.lower() in chunk_text.lower():
+            # Boost score for exact matches
+            matches.append((chunk, max(similarity, 0.9)))
+
+    # Remove duplicates and sort by similarity (highest first)
+    unique_matches = {}
+    for chunk, score in matches:
+        chunk_id = chunk['chunk_id']
+        if chunk_id not in unique_matches or score > unique_matches[chunk_id][1]:
+            unique_matches[chunk_id] = (chunk, score)
+
+    sorted_matches = sorted(unique_matches.values(), key=lambda x: x[1], reverse=True)
+
+    return sorted_matches
+
+
+def create_evidence_item(chunk: ChunkArtifact, confidence: float) -> EvidenceItem:
+    """
+    Create an evidence item from a chunk.
+
+    Args:
+        chunk: Chunk artifact
+        confidence: Confidence score
+
+    Returns:
+        Evidence item
+    """
+    # Extract snippet (limit to 200 characters)
+    snippet = chunk['text']
+    if len(snippet) > 200:
+        snippet = snippet[:197] + "..."
+
+    evidence: EvidenceItem = {
+        'source_id': chunk['source_id'],
+        'source_type': chunk['source'],
+        'snippet': snippet,
+        'confidence': confidence,
+        'metadata': {
+            'chunk_id': chunk['chunk_id'],
+            'full_text': chunk['text'],
+            'start': chunk.get('start'),
+            'end': chunk.get('end'),
+            'original_metadata': chunk.get('metadata', {})
+        }
+    }
+
+    return evidence
+
+
+def retrieve_evidence_node(state: GraphState, ctx: AgentContext) -> GraphState:
+    """
+    Retrieve supporting evidence for candidate facts.
+
+    Layer 2 — Record-time evidence check:
+      - If EmbeddingService is available, uses pgvector cosine search (O(log n))
+      - Otherwise falls back to SequenceMatcher fuzzy matching (O(n*m))
+
+    For each candidate fact:
+    - Find source spans in chunks using similarity search
+    - Calculate confidence scores based on similarity
+    - Store evidence in evidence_map
+    - Fall back to full transcript if no specific span found
+
+    Args:
+        state: Current graph state
+        ctx: AgentContext with optional embedding_service
+
+    Returns:
+        Updated state with populated evidence_map
+    """
+    candidate_facts = state.get('candidate_facts', [])
+    chunks = state.get('chunks', [])
+    conversation_log = state.get('conversation_log', [])
+    session_id = state.get('session_id', '')
+
+    if not candidate_facts:
+        state['controls']['trace_log'].append({
+            'node': 'retrieve_evidence',
+            'action': 'skipped',
+            'reason': 'no_candidate_facts',
+            'timestamp': datetime.now().isoformat()
+        })
+        return state
+
+    # Decide strategy: pgvector or fallback
+    use_vector_search = (
+        ctx is not None
+        and ctx.embedding_service is not None
+        and session_id
+    )
+
+    evidence_map: Dict[str, List[EvidenceItem]] = {}
+    facts_with_evidence = 0
+    facts_without_evidence = 0
+
+    if use_vector_search:
+        logger.info("[Evidence] Using pgvector cosine search")
+        evidence_map, facts_with_evidence, facts_without_evidence = (
+            _retrieve_via_embeddings(
+                candidate_facts, chunks, conversation_log,
+                session_id, ctx
+            )
+        )
+    else:
+        logger.info("[Evidence] Using SequenceMatcher fallback")
+        evidence_map, facts_with_evidence, facts_without_evidence = (
+            _retrieve_via_fuzzy_match(candidate_facts, chunks, conversation_log)
+        )
+
+    # Update state
+    state['evidence_map'] = evidence_map
+
+    # Log the operation
+    state['controls']['trace_log'].append({
+        'node': 'retrieve_evidence',
+        'action': 'retrieved',
+        'strategy': 'pgvector' if use_vector_search else 'fuzzy_match',
+        'total_facts': len(candidate_facts),
+        'facts_with_evidence': facts_with_evidence,
+        'facts_without_evidence': facts_without_evidence,
+        'total_evidence_items': sum(len(items) for items in evidence_map.values()),
+        'timestamp': datetime.now().isoformat()
+    })
+
+    return state
+
+
+def _retrieve_via_embeddings(
+    candidate_facts: List[CandidateFact],
+    chunks: List[ChunkArtifact],
+    conversation_log: list,
+    session_id: str,
+    ctx: AgentContext,
+) -> tuple:
+    """Layer 2 — pgvector cosine search for evidence retrieval."""
+    evidence_map: Dict[str, List[EvidenceItem]] = {}
+    facts_with = 0
+    facts_without = 0
+
+    for fact in candidate_facts:
+        fact_id = fact['fact_id']
+        search_text = fact_to_search_string(fact)
+
+        try:
+            query_vec = ctx.embedding_service.embed_text(search_text)
+            matches = ctx.embedding_service.search_similar_chunks(
+                session_id=session_id,
+                query_embedding=query_vec,
+                top_k=5,
+                threshold=0.45,
+            )
+
+            if matches:
+                evidence_items = []
+                for match in matches:
+                    snippet = match['chunk_text']
+                    if len(snippet) > 200:
+                        snippet = snippet[:197] + "..."
+
+                    evidence_item: EvidenceItem = {
+                        'source_id': match['chunk_id'],
+                        'source_type': match['source_type'],
+                        'snippet': snippet,
+                        'confidence': match['similarity'],
+                        'metadata': {
+                            'chunk_id': match['chunk_id'],
+                            'full_text': match['chunk_text'],
+                            'start': match.get('start_time'),
+                            'end': match.get('end_time'),
+                            'retrieval': 'pgvector',
+                        }
+                    }
+                    evidence_items.append(evidence_item)
+
+                evidence_map[fact_id] = evidence_items
+                facts_with += 1
+            else:
+                # Fallback to transcript context
+                evidence_map[fact_id] = _fallback_evidence(conversation_log)
+                facts_without += 1
+
+        except Exception as e:
+            logger.warning(f"[Evidence] pgvector search failed for fact {fact_id}: {e}")
+            # Fall back to fuzzy matching for this fact
+            fm_matches = find_matching_chunks(fact, chunks, threshold=FUZZY_MATCH_THRESHOLD)
+            if fm_matches:
+                evidence_map[fact_id] = [
+                    create_evidence_item(chunk, sim) for chunk, sim in fm_matches[:5]
+                ]
+                facts_with += 1
+            else:
+                evidence_map[fact_id] = _fallback_evidence(conversation_log)
+                facts_without += 1
+
+    return evidence_map, facts_with, facts_without
+
+
+def _retrieve_via_fuzzy_match(
+    candidate_facts: List[CandidateFact],
+    chunks: List[ChunkArtifact],
+    conversation_log: list,
+) -> tuple:
+    """Original O(n*m) SequenceMatcher evidence retrieval (fallback)."""
+    evidence_map: Dict[str, List[EvidenceItem]] = {}
+    facts_with = 0
+    facts_without = 0
+
+    for fact in candidate_facts:
+        fact_id = fact['fact_id']
+        matches = find_matching_chunks(fact, chunks, threshold=FUZZY_MATCH_THRESHOLD)
+
+        if matches:
+            evidence_items = [
+                create_evidence_item(chunk, similarity)
+                for chunk, similarity in matches[:5]
+            ]
+            evidence_map[fact_id] = evidence_items
+            facts_with += 1
+        else:
+            evidence_map[fact_id] = _fallback_evidence(conversation_log)
+            facts_without += 1
+
+    return evidence_map, facts_with, facts_without
+
+
+def _fallback_evidence(conversation_log: list) -> List[EvidenceItem]:
+    """Build fallback evidence from conversation log."""
+    full_transcript_parts = []
+    for turn in conversation_log[:3]:
+        for segment in turn.get('segments', []):
+            text = segment.get('cleaned_text') or segment.get('raw_text', '')
+            if text:
+                full_transcript_parts.append(text)
+
+    if full_transcript_parts:
+        full_text = ' '.join(full_transcript_parts)
+        snippet = full_text[:200] + "..." if len(full_text) > 200 else full_text
+        return [{
+            'source_id': 'full_transcript',
+            'source_type': 'transcript',
+            'snippet': snippet,
+            'confidence': 0.3,
+            'metadata': {
+                'fallback': True,
+                'reason': 'no_specific_match_found',
+                'full_text': full_text
+            }
+        }]
+    return []

--- a/server/app/agents/nodes/extract.py
+++ b/server/app/agents/nodes/extract.py
@@ -1,0 +1,452 @@
+"""
+Agent B — Candidate Extractor (Initial Extraction)
+
+Purpose: Extract typed candidate facts with confidence scores and evidence spans.
+Deterministic work: canonicalize entities, assign strict fact_type schema.
+Output quality: All candidates must include at least one evidence span.
+
+DB integration:
+  - Reads patient_record_fields (prior history) to augment the LLM prompt
+  - Uses EmbeddingService (Layer 1) to verify grounding of extracted facts
+"""
+
+import json
+import logging
+import re
+from typing import Dict, List, Any, Optional
+from uuid import uuid4
+
+from ..config import AgentContext
+from ..state import GraphState
+from ...models.llm import LLMClient
+
+logger = logging.getLogger(__name__)
+
+
+# Medical entity canonicalization mappings
+MEDICATION_ALIASES = {
+    "amoxicillin": ["amoxicillin", "amoxil", "moxatag"],
+    "lisinopril": ["lisinopril", "prinivil", "zestril"],
+    "metformin": ["metformin", "glucophage", "fortamet"],
+    "atorvastatin": ["atorvastatin", "lipitor"],
+    "levothyroxine": ["levothyroxine", "synthroid", "levoxyl"],
+    "amlodipine": ["amlodipine", "norvasc"],
+    "metoprolol": ["metoprolol", "lopressor", "toprol"],
+    "omeprazole": ["omeprazole", "prilosec"],
+}
+
+ALLERGY_ALIASES = {
+    "penicillin": ["penicillin", "pcn", "pen"],
+    "sulfa": ["sulfa", "sulfamethoxazole", "sulfonamide"],
+    "aspirin": ["aspirin", "asa"],
+    "codeine": ["codeine"],
+    "morphine": ["morphine"],
+}
+
+
+def extract_candidates_node(state: GraphState, ctx: AgentContext) -> GraphState:
+    """
+    Extract candidate clinical facts from chunks using LLM with structured output.
+    
+    Agent B: Candidate Extractor
+    - Extracts: patient demographics, allergies, medications, diagnoses, vitals, labs
+    - Assigns confidence scores (0.0-1.0)
+    - Creates evidence spans with provenance
+    - Canonicalizes drug names and allergens
+    - Injects patient history from DB into LLM prompt (if available)
+    - Applies Layer 1 grounding verification via embeddings (if available)
+    - Retries on invalid JSON (bounded by budget)
+    """
+    state = state.copy() if isinstance(state, dict) else state
+    
+    chunks = state.get("chunks", [])
+    if not chunks:
+        # Fallback: extract from conversation_log if chunks not available yet
+        chunks = _create_chunks_from_conversation_log(state)
+    
+    candidates: List[Dict[str, Any]] = []
+    controls = state.get("controls", {"attempts": {}, "budget": {}})
+    
+    # Track extraction attempts
+    node_name = "extract_candidates"
+    attempts = controls.get("attempts", {})
+    attempts[node_name] = attempts.get(node_name, 0) + 1
+    
+    # Budget tracking
+    budget = controls.get("budget", {})
+    max_llm_calls = budget.get("max_total_llm_calls", ctx.max_llm_calls if ctx else 30)
+    llm_calls_used = budget.get("llm_calls_used", 0)
+    
+    if llm_calls_used >= max_llm_calls:
+        print(f"[Extract Candidates] Budget exhausted: {llm_calls_used}/{max_llm_calls} LLM calls")
+        state["candidate_facts"] = candidates
+        return state
+    
+    # Build patient history context from DB (if loaded)
+    patient_history_prompt = _build_patient_history_prompt(state)
+    
+    # Process chunks in batches for efficiency
+    batch_size = 3
+    for i in range(0, len(chunks), batch_size):
+        batch = chunks[i:i+batch_size]
+        batch_text = "\n\n---\n\n".join([
+            f"[Chunk {j}] ({chunk.get('source', 'unknown')})\n{chunk.get('text', '')}"
+            for j, chunk in enumerate(batch, start=i)
+        ])
+        
+        # Extract candidates with retry logic
+        max_retries = 2
+        for retry in range(max_retries + 1):
+            try:
+                llm_calls_used += 1
+                extracted = _call_extraction_llm(batch_text, batch, retry, patient_history_prompt)
+                
+                if extracted:
+                    candidates.extend(extracted)
+                    break  # Success
+                    
+            except json.JSONDecodeError as e:
+                print(f"[Extract Candidates] JSON decode error (attempt {retry+1}): {e}")
+                if retry == max_retries:
+                    # Failed after retries - create low-confidence fallback
+                    candidates.extend(_create_fallback_candidates(batch))
+            except Exception as e:
+                print(f"[Extract Candidates] Error: {e}")
+                if retry == max_retries:
+                    candidates.extend(_create_fallback_candidates(batch))
+        
+        if llm_calls_used >= max_llm_calls:
+            print(f"[Extract Candidates] Budget limit reached during processing")
+            break
+    
+    # Canonicalize entities
+    candidates = _canonicalize_candidates(candidates)
+    
+    # Ensure all candidates have evidence spans
+    candidates = _ensure_evidence_spans(candidates, chunks)
+    
+    # Layer 1: Grounding verification via embeddings (if available)
+    if ctx and ctx.embedding_service is not None:
+        candidates = _apply_grounding_verification(candidates, ctx)
+    
+    # Update state
+    state["candidate_facts"] = candidates
+    controls["attempts"] = attempts
+    budget["llm_calls_used"] = llm_calls_used
+    controls["budget"] = budget
+    state["controls"] = controls
+    
+    print(f"[Extract Candidates] Extracted {len(candidates)} candidate facts "
+          f"(LLM calls: {llm_calls_used}/{max_llm_calls})")
+    
+    return state
+
+
+def _call_extraction_llm(text: str, chunks: List[Dict], retry_count: int, patient_history_prompt: str = "") -> List[Dict[str, Any]]:
+    """Call LLM to extract structured medical entities."""
+    
+    prompt = """You are a medical entity extraction system. Extract clinical facts from the text.
+
+CRITICAL: Return ONLY valid JSON. No explanations, no markdown, just JSON.
+
+Extract these entity types:
+- patient_demographics: name, dob, age, sex, mrn
+- allergy: substance, reaction, severity
+- medication: name, dose, route, frequency, start_date
+- diagnosis: code, description (ICD-10 if available)
+- vital: type (BP, HR, Temp, RR, O2), value, unit, timestamp
+- lab_result: test_name, value, unit, reference_range, date
+- procedure: name, date, location
+- followup: description, timeframe
+
+For EACH entity, provide:
+1. fact_type: one of the types above
+2. value: dict with entity-specific fields
+3. confidence: 0.0-1.0 (how certain you are)
+4. evidence_text: exact quote from source (15-50 words)
+
+"""
+    
+    # Inject patient history context if available
+    if patient_history_prompt:
+        prompt += patient_history_prompt + "\n"
+    
+    prompt += """Output format:
+{
+  "facts": [
+    {
+      "fact_type": "medication",
+      "value": {"name": "Lisinopril", "dose": "10mg", "frequency": "daily"},
+      "confidence": 0.95,
+      "evidence_text": "patient taking Lisinopril 10mg once daily"
+    }
+  ]
+}
+
+Text to analyze:
+"""
+    
+    if retry_count > 0:
+        prompt += "\n\nIMPORTANT: Previous attempt failed. Return ONLY valid JSON with no extra text.\n\n"
+    
+    prompt += f"\n{text}\n\nJSON output:"
+    
+    llm = LLMClient()
+    response = llm.generate_response(prompt)
+    
+    # Clean response - remove markdown code blocks if present
+    response = response.strip()
+    if response.startswith("```"):
+        # Remove markdown code fences
+        response = re.sub(r'^```(?:json)?\s*\n', '', response)
+        response = re.sub(r'\n```\s*$', '', response)
+    
+    # Parse JSON
+    data = json.loads(response)
+    
+    # Convert to internal format with proper IDs and evidence spans
+    candidates = []
+    for fact in data.get("facts", []):
+        fact_id = str(uuid4())[:8]
+        fact_type = fact.get("fact_type", "unknown")
+        value = fact.get("value", {})
+        confidence = fact.get("confidence", 0.5)
+        evidence_text = fact.get("evidence_text", "")
+        
+        # Create evidence span (will be refined later)
+        evidence_span = {
+            "source": chunks[0].get("source", "transcript") if chunks else "transcript",
+            "source_id": chunks[0].get("source_id", "unknown") if chunks else "unknown",
+            "locator": {},
+            "snippet": evidence_text[:200],
+            "strength": confidence
+        }
+        
+        candidate = {
+            "fact_id": fact_id,
+            "type": fact_type,
+            "value": value,
+            "confidence": confidence,
+            "provenance": {"evidence": [evidence_span]},
+            "normalized": False,
+            "conflict_group": None
+        }
+        candidates.append(candidate)
+    
+    return candidates
+
+
+def _create_chunks_from_conversation_log(state: GraphState) -> List[Dict[str, Any]]:
+    """Fallback: create chunks from conversation log if chunks not yet generated."""
+    chunks = []
+    conversation_log = state.get("conversation_log", [])
+    
+    for log_entry in conversation_log:
+        for seg in log_entry.get("segments", []):
+            chunk = {
+                "chunk_id": str(uuid4())[:8],
+                "source": "transcript",
+                "source_id": state.get("session_id", "unknown"),
+                "start": seg.get("start"),
+                "end": seg.get("end"),
+                "text": seg.get("cleaned_text") or seg.get("raw_text", ""),
+                "metadata": {"speaker": seg.get("speaker", "unknown")}
+            }
+            chunks.append(chunk)
+    
+    return chunks
+
+
+def _create_fallback_candidates(chunks: List[Dict]) -> List[Dict[str, Any]]:
+    """Create low-confidence fallback candidates when LLM extraction fails."""
+    candidates = []
+    
+    for chunk in chunks:
+        text = chunk.get("text", "").lower()
+        
+        # Simple regex-based extraction as fallback
+        # Medications: look for common drug names
+        for canonical_name, aliases in MEDICATION_ALIASES.items():
+            for alias in aliases:
+                if alias in text:
+                    candidates.append({
+                        "fact_id": str(uuid4())[:8],
+                        "type": "medication",
+                        "value": {"name": canonical_name},
+                        "confidence": 0.3,
+                        "provenance": {"evidence": [{
+                            "source": chunk.get("source", "transcript"),
+                            "source_id": chunk.get("source_id", "unknown"),
+                            "locator": {},
+                            "snippet": text[:100],
+                            "strength": 0.3
+                        }]},
+                        "normalized": True,
+                        "conflict_group": None
+                    })
+                    break
+    
+    return candidates
+
+
+def _canonicalize_candidates(candidates: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Canonicalize drug names and allergens to standard forms."""
+    
+    for candidate in candidates:
+        fact_type = candidate.get("type", "")
+        value = candidate.get("value", {})
+        
+        if fact_type == "medication" and "name" in value:
+            med_name = value["name"].lower()
+            # Check if this is an alias
+            for canonical, aliases in MEDICATION_ALIASES.items():
+                if med_name in aliases:
+                    value["name"] = canonical.capitalize()
+                    value["original_name"] = med_name
+                    candidate["normalized"] = True
+                    break
+        
+        elif fact_type == "allergy" and "substance" in value:
+            allergy_name = value["substance"].lower()
+            for canonical, aliases in ALLERGY_ALIASES.items():
+                if allergy_name in aliases:
+                    value["substance"] = canonical.capitalize()
+                    value["original_substance"] = allergy_name
+                    candidate["normalized"] = True
+                    break
+    
+    return candidates
+
+
+def _ensure_evidence_spans(candidates: List[Dict[str, Any]], chunks: List[Dict]) -> List[Dict[str, Any]]:
+    """Ensure all candidates have at least one evidence span with proper locators."""
+    
+    for candidate in candidates:
+        provenance = candidate.get("provenance", {})
+        evidence_list = provenance.get("evidence", []) if isinstance(provenance, dict) else []
+        
+        if not evidence_list:
+            # Create minimal evidence span
+            evidence_list = [{
+                "source": "transcript",
+                "source_id": "unknown",
+                "locator": {},
+                "snippet": f"Extracted {candidate.get('type', 'fact')}",
+                "strength": candidate.get("confidence", 0.5)
+            }]
+            candidate["provenance"] = {"evidence": evidence_list}
+        
+        # Enhance evidence with better locators if possible
+        for evidence in evidence_list:
+            if not evidence.get("locator"):
+                snippet = evidence.get("snippet", "")
+                # Try to find matching chunk
+                for chunk in chunks:
+                    if snippet[:50] in chunk.get("text", ""):
+                        if chunk.get("source") == "transcript":
+                            evidence["locator"] = {
+                                "start_time": chunk.get("start_time"),
+                                "end_time": chunk.get("end_time")
+                            }
+                        else:
+                            evidence["locator"] = {
+                                "start_char": chunk.get("start_char"),
+                                "end_char": chunk.get("end_char")
+                            }
+                        break
+    
+    return candidates
+
+
+# ─── Patient history prompt builder ─────────────────────────────────────────
+
+def _build_patient_history_prompt(state: GraphState) -> str:
+    """
+    Build a context section for the LLM prompt from patient_record_fields.
+
+    If load_patient_context has populated the state with prior facts,
+    we inject them so the LLM can:
+      - Cross-reference existing allergies / medications
+      - Flag new vs. previously-known findings
+      - Increase confidence for corroborated facts
+    """
+    prf = state.get("patient_record_fields")
+    if not prf or not prf.get("loaded_from_db"):
+        return ""
+
+    sections = []
+    sections.append("PATIENT HISTORY (from database — use for cross-referencing, NOT as new evidence):")
+
+    # Demographics
+    demo = prf.get("demographics", {})
+    if demo:
+        sections.append(f"  Patient: {demo.get('full_name', 'Unknown')}, "
+                        f"DOB: {demo.get('dob', 'N/A')}, "
+                        f"Sex: {demo.get('sex', 'N/A')}")
+
+    # Prior facts
+    prior_facts = prf.get("prior_facts", {})
+    if prior_facts:
+        for fact_type, facts in prior_facts.items():
+            keys = [f.get("fact_key", "?") for f in facts[:5]]
+            sections.append(f"  Known {fact_type}s: {', '.join(keys)}")
+
+    sections.append(
+        "INSTRUCTIONS: If you extract a fact that matches a known item above, "
+        "boost its confidence. If it contradicts, flag it and keep both."
+    )
+
+    return "\n".join(sections)
+
+
+# ─── Layer 1: Grounding verification ────────────────────────────────────────
+
+def _apply_grounding_verification(
+    candidates: List[Dict[str, Any]],
+    ctx: AgentContext,
+) -> List[Dict[str, Any]]:
+    """
+    Layer 1 — Extraction-time span verification.
+
+    For each candidate that has an evidence snippet, compute cosine
+    similarity between the snippet and the fact text. If below the
+    grounding threshold, downgrade confidence.
+    """
+    if ctx.embedding_service is None:
+        return candidates
+
+    for candidate in candidates:
+        provenance = candidate.get("provenance", {})
+        evidence_list = provenance.get("evidence", []) if isinstance(provenance, dict) else []
+        if not evidence_list:
+            continue
+
+        snippet = evidence_list[0].get("snippet", "")
+        if not snippet or len(snippet) < 10:
+            continue
+
+        try:
+            fact_text = ctx.embedding_service._fact_to_text(candidate)
+            grounding_score, is_grounded = ctx.embedding_service.verify_grounding(
+                source_span=snippet,
+                extracted_text=fact_text,
+            )
+
+            candidate["grounding_score"] = grounding_score
+
+            if not is_grounded:
+                # Downgrade confidence for ungrounded facts
+                original_conf = candidate.get("confidence", 0.5)
+                candidate["confidence"] = min(original_conf, 0.4)
+                candidate["grounding_warning"] = (
+                    f"Low grounding score ({grounding_score:.3f}) — "
+                    "fact may not be well-supported by source text"
+                )
+                logger.warning(
+                    f"[Extract] Fact {candidate.get('fact_id')} failed grounding: "
+                    f"{grounding_score:.3f} < {ctx.grounding_threshold}"
+                )
+        except Exception as e:
+            logger.debug(f"[Extract] Grounding check failed for {candidate.get('fact_id')}: {e}")
+
+    return candidates

--- a/server/app/agents/nodes/fill_record.py
+++ b/server/app/agents/nodes/fill_record.py
@@ -1,0 +1,322 @@
+"""
+Agent D — Record Compiler (Schema Mapper)
+
+Purpose: Assemble canonical structured record from candidate facts with field provenance.
+Deterministic work: Field mapping rules, merge duplicates, prefer higher confidence.
+Hard constraint: Only compile from candidates with evidence.
+
+DB integration:
+  - Pre-seeds patient demographics from patient_record_fields (DB-loaded)
+  - Merges with prior record baseline so returning patients keep their history
+"""
+
+from typing import Dict, List, Any, Optional
+from ..state import GraphState
+
+
+# Field mapping rules: fact_type -> record path
+FACT_TYPE_MAPPING = {
+    # Patient demographics
+    "patient_name": ["patient", "name"],
+    "patient_dob": ["patient", "dob"],
+    "patient_age": ["patient", "age"],
+    "patient_sex": ["patient", "sex"],
+    "patient_mrn": ["patient", "mrn"],
+    "patient_demographics": ["patient"],  # Composite
+    
+    # Allergies
+    "allergy": ["allergies"],
+    
+    # Medications
+    "medication": ["medications"],
+    
+    # Diagnoses
+    "diagnosis": ["diagnoses"],
+    
+    # Vitals
+    "vital": ["vitals"],
+    
+    # Labs
+    "lab_result": ["labs"],
+    
+    # Procedures
+    "procedure": ["procedures"],
+    
+    # Follow-ups
+    "followup": ["followups"],
+    
+    # Problem list
+    "problem_list": ["problems"],
+}
+
+
+def fill_structured_record_node(state: GraphState) -> GraphState:
+    """
+    Fill the structured clinical record from candidate facts and evidence.
+    
+    Agent D: Record Compiler
+    - Pre-seeds patient demographics from DB (if available via patient_record_fields)
+    - Maps candidate facts to structured record schema
+    - Builds field-level provenance tracking
+    - Merges duplicates (prefers higher confidence)
+    - Only uses candidates that have evidence
+    """
+    state = state.copy() if isinstance(state, dict) else state
+    
+    candidates = state.get("candidate_facts", [])
+    
+    # Initialize empty record structure
+    record = {
+        "patient": {},
+        "visit": {},
+        "allergies": [],
+        "medications": [],
+        "diagnoses": [],
+        "vitals": [],
+        "labs": [],
+        "procedures": [],
+        "followups": [],
+        "problems": [],
+        "notes": {}
+    }
+    
+    # ── Pre-seed from DB patient context ────────────────────────────────────
+    prf = state.get("patient_record_fields") or {}
+    demographics = prf.get("demographics", {})
+    if demographics:
+        record["patient"] = {
+            "name": demographics.get("full_name", ""),
+            "dob": demographics.get("dob", ""),
+            "age": demographics.get("age"),
+            "sex": demographics.get("sex", ""),
+            "mrn": demographics.get("mrn", ""),
+        }
+        print(f"[Fill Record] Pre-seeded patient demographics from DB: {record['patient'].get('name', 'N/A')}")
+
+    # Merge prior record baseline (returning patient)
+    prior_record = prf.get("prior_record", {})
+    if prior_record:
+        # Carry forward list-type fields from prior record as baseline
+        for list_field in ("allergies", "medications", "diagnoses", "problems"):
+            prior_items = prior_record.get(list_field, [])
+            if prior_items and isinstance(prior_items, list):
+                for item in prior_items:
+                    if isinstance(item, dict):
+                        item.setdefault("source", "prior_record")
+                        item.setdefault("confidence", 0.8)  # High confidence for DB records
+                record[list_field] = list(prior_items)
+        print(f"[Fill Record] Merged {sum(len(prior_record.get(f, [])) for f in ('allergies', 'medications', 'diagnoses', 'problems'))} items from prior record")
+    
+    provenance: List[Dict[str, Any]] = []
+    
+    # Track what we've seen to handle duplicates
+    seen_items: Dict[str, Dict[str, Any]] = {}
+    
+    # Process each candidate
+    for candidate in candidates:
+        fact_type = candidate.get("type", candidate.get("fact_type", ""))
+        value = candidate.get("value", {})
+        confidence = candidate.get("confidence", 0.5)
+        # Support both new (provenance.evidence) and legacy (evidence) shapes
+        prov = candidate.get("provenance", {})
+        if isinstance(prov, dict) and prov.get("evidence"):
+            evidence = prov["evidence"]
+        else:
+            evidence = candidate.get("evidence", [])
+        
+        # Skip candidates without evidence (hard constraint)
+        if not evidence:
+            continue
+        
+        # Map to record structure
+        if fact_type == "patient_demographics":
+            _fill_patient_demographics(record, value, confidence, evidence, provenance)
+        
+        elif fact_type in ["patient_name", "patient_dob", "patient_age", "patient_sex", "patient_mrn"]:
+            _fill_patient_field(record, fact_type, value, confidence, evidence, provenance)
+        
+        elif fact_type == "allergy":
+            _append_unique_to_list(
+                record, "allergies", value, confidence, evidence, provenance,
+                "substance", seen_items
+            )
+        
+        elif fact_type == "medication":
+            _append_unique_to_list(
+                record, "medications", value, confidence, evidence, provenance,
+                "name", seen_items
+            )
+        
+        elif fact_type == "diagnosis":
+            _append_unique_to_list(
+                record, "diagnoses", value, confidence, evidence, provenance,
+                "code", seen_items
+            )
+        
+        elif fact_type == "vital":
+            _append_to_list(
+                record, "vitals", value, confidence, evidence, provenance
+            )
+        
+        elif fact_type == "lab_result":
+            _append_unique_to_list(
+                record, "labs", value, confidence, evidence, provenance,
+                "test", seen_items
+            )
+        
+        elif fact_type == "procedure":
+            _append_unique_to_list(
+                record, "procedures", value, confidence, evidence, provenance,
+                "name", seen_items
+            )
+        
+        elif fact_type == "followup":
+            _append_to_list(
+                record, "followups", value, confidence, evidence, provenance
+            )
+        
+        elif fact_type == "problem_list":
+            _append_unique_to_list(
+                record, "problems", value, confidence, evidence, provenance,
+                "name", seen_items
+            )
+    
+    # Update state
+    state["structured_record"] = record
+    state["provenance"] = provenance
+    
+    # Track node execution
+    if "controls" not in state:
+        state["controls"] = {"attempts": {}, "budget": {}, "trace_log": []}
+    state["controls"]["attempts"]["fill_structured_record"] = \
+        state["controls"]["attempts"].get("fill_structured_record", 0) + 1
+    
+    print(f"[Fill Record] Compiled {len(candidates)} candidates into structured record")
+    print(f"  - Allergies: {len(record['allergies'])}")
+    print(f"  - Medications: {len(record['medications'])}")
+    print(f"  - Diagnoses: {len(record['diagnoses'])}")
+    print(f"  - Vitals: {len(record['vitals'])}")
+    print(f"  - Labs: {len(record['labs'])}")
+    
+    return state
+
+
+def _fill_patient_demographics(record: Dict, value: Dict, confidence: float, 
+                                evidence: List, provenance: List):
+    """Fill patient demographics from composite value."""
+    for field in ["name", "dob", "age", "sex", "mrn"]:
+        if field in value:
+            record["patient"][field] = value[field]
+            provenance.append({
+                "field_path": f"patient.{field}",
+                "evidence": evidence,
+                "confidence": confidence
+            })
+
+
+def _fill_patient_field(record: Dict, fact_type: str, value: Any, confidence: float,
+                        evidence: List, provenance: List):
+    """Fill a single patient field."""
+    field_name = fact_type.replace("patient_", "")
+    
+    # Handle both simple values and dict values
+    if isinstance(value, dict):
+        actual_value = value.get(field_name, value.get("value"))
+    else:
+        actual_value = value
+    
+    if actual_value is not None:
+        record["patient"][field_name] = actual_value
+        provenance.append({
+            "field_path": f"patient.{field_name}",
+            "evidence": evidence,
+            "confidence": confidence
+        })
+
+
+def _append_to_list(record: Dict, list_name: str, value: Dict, confidence: float,
+                    evidence: List, provenance: List):
+    """Append item to list without duplicate checking."""
+    if isinstance(value, dict):
+        value["confidence"] = confidence
+    
+    record[list_name].append(value)
+    
+    idx = len(record[list_name]) - 1
+    provenance.append({
+        "field_path": f"{list_name}[{idx}]",
+        "evidence": evidence,
+        "confidence": confidence
+    })
+
+
+def _append_unique_to_list(record: Dict, list_name: str, value: Dict, confidence: float,
+                           evidence: List, provenance: List, merge_key: str,
+                           seen_items: Dict):
+    """
+    Append item to list with duplicate detection and merging.
+    Prefers higher confidence when merging duplicates.
+    """
+    # Get merge key value
+    merge_value = value.get(merge_key)
+    if not merge_value:
+        # No merge key, just append
+        _append_to_list(record, list_name, value, confidence, evidence, provenance)
+        return
+    
+    # Check if we've seen this before
+    seen_key = f"{list_name}:{merge_value}"
+    
+    if seen_key in seen_items:
+        existing = seen_items[seen_key]
+        existing_confidence = existing.get("confidence", 0.0)
+        
+        # Merge: prefer higher confidence
+        if confidence > existing_confidence:
+            # Replace with higher confidence version
+            idx = existing.get("index")
+            value["confidence"] = confidence
+            record[list_name][idx] = value
+            
+            # Update provenance
+            for i, prov in enumerate(provenance):
+                if prov["field_path"] == f"{list_name}[{idx}]":
+                    provenance[i] = {
+                        "field_path": f"{list_name}[{idx}]",
+                        "evidence": evidence,
+                        "confidence": confidence
+                    }
+                    break
+            
+            # Update seen_items
+            seen_items[seen_key] = {
+                "confidence": confidence,
+                "index": idx,
+                "value": value
+            }
+        else:
+            # Keep existing (higher confidence), but could merge fields
+            idx = existing.get("index")
+            existing_item = record[list_name][idx]
+            
+            # Merge additional fields that don't exist
+            for key, val in value.items():
+                if key not in existing_item or not existing_item[key]:
+                    existing_item[key] = val
+    else:
+        # First time seeing this, append it
+        value["confidence"] = confidence
+        record[list_name].append(value)
+        idx = len(record[list_name]) - 1
+        
+        provenance.append({
+            "field_path": f"{list_name}[{idx}]",
+            "evidence": evidence,
+            "confidence": confidence
+        })
+        
+        seen_items[seen_key] = {
+            "confidence": confidence,
+            "index": idx,
+            "value": value
+        }

--- a/server/app/agents/nodes/record_schema.py
+++ b/server/app/agents/nodes/record_schema.py
@@ -1,0 +1,75 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class Patient(BaseModel):
+    name: str
+    dob: str
+    age: Optional[int] = None
+    sex: Optional[str] = None
+    mrn: Optional[str] = None
+
+
+class Visit(BaseModel):
+    date: str
+    type: Optional[str] = None
+    location: Optional[str] = None
+    provider: Optional[str] = None
+
+
+class Diagnosis(BaseModel):
+    code: str
+    description: Optional[str] = None
+    confidence: Optional[float] = None
+
+
+class Medication(BaseModel):
+    name: str
+    dose: Optional[str] = None
+    route: Optional[str] = None
+    frequency: Optional[str] = None
+    start_date: Optional[str] = None
+    confidence: Optional[float] = None
+
+
+class Allergy(BaseModel):
+    substance: str
+    reaction: Optional[str] = None
+    severity: Optional[str] = None
+
+
+class Problem(BaseModel):
+    name: str
+    status: Optional[str] = None
+
+
+class Lab(BaseModel):
+    test: str
+    value: Optional[str] = None
+    unit: Optional[str] = None
+    date: Optional[str] = None
+
+
+class Procedure(BaseModel):
+    name: str
+    date: Optional[str] = None
+
+
+class Notes(BaseModel):
+    subjective: Optional[str] = None
+    objective: Optional[str] = None
+    assessment: Optional[str] = None
+    plan: Optional[str] = None
+
+
+class StructuredRecord(BaseModel):
+    patient: Patient
+    visit: Visit
+    diagnoses: List[Diagnosis] = Field(default_factory=list)
+    medications: List[Medication] = Field(default_factory=list)
+    allergies: List[Allergy] = Field(default_factory=list)
+    problems: List[Problem] = Field(default_factory=list)
+    labs: List[Lab] = Field(default_factory=list)
+    procedures: List[Procedure] = Field(default_factory=list)
+    notes: Optional[Notes] = None

--- a/server/app/services/embedding_service.py
+++ b/server/app/services/embedding_service.py
@@ -1,0 +1,464 @@
+"""
+EmbeddingService — Medical-domain text embeddings with pgvector.
+
+Uses BioLord-2023-M (768-dim) for clinical text embeddings that capture
+medical semantics (drug–drug, symptom–diagnosis proximity) far better
+than general-purpose models.
+
+Three-layer grounding architecture:
+  Layer 1 — Extraction-time span verification
+  Layer 2 — Record-time evidence retrieval (cosine search)
+  Layer 3 — Persistence-time confidence gating
+
+The service wraps sentence-transformers and provides:
+  - embed_text / embed_texts: raw embedding generation
+  - store_chunk_embedding: persist chunk vectors for evidence retrieval
+  - store_clinical_embedding: persist fact vectors for patient context
+  - search_similar_chunks: cosine-distance top-k against chunk_embeddings
+  - search_similar_facts: cosine-distance top-k against clinical_embeddings
+  - verify_grounding: Layer 1 — check that extracted fact is grounded in source span
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+from sqlalchemy.orm import Session as DBSession
+from sqlalchemy import text as sql_text
+
+logger = logging.getLogger(__name__)
+
+# ─── Constants ──────────────────────────────────────────────────────────────
+
+# BioLord-2023-M: biomedical / clinical domain, 768-dim
+DEFAULT_MODEL_NAME = "FremyCompany/BioLord-2023-M"
+EMBEDDING_DIM = 768
+DEFAULT_GROUNDING_THRESHOLD = 0.65
+DEFAULT_PERSISTENCE_FLOOR = 0.60
+
+
+class EmbeddingService:
+    """
+    Manages medical-domain text embeddings and pgvector persistence.
+
+    Usage:
+        svc = EmbeddingService(db_session)
+        vec = svc.embed_text("patient allergic to penicillin")
+        svc.store_clinical_embedding(patient_id, session_id, fact, vec)
+        matches = svc.search_similar_chunks(session_id, query_vec, top_k=5)
+    """
+
+    def __init__(
+        self,
+        db: Optional[DBSession] = None,
+        model_name: str = DEFAULT_MODEL_NAME,
+        grounding_threshold: float = DEFAULT_GROUNDING_THRESHOLD,
+        persistence_floor: float = DEFAULT_PERSISTENCE_FLOOR,
+    ):
+        self.db = db
+        self.model_name = model_name
+        self.grounding_threshold = grounding_threshold
+        self.persistence_floor = persistence_floor
+        self._model = None
+
+    # ── Lazy model loading ──────────────────────────────────────────────────
+
+    @property
+    def model(self):
+        """Lazy-load sentence-transformers model to avoid startup cost."""
+        if self._model is None:
+            try:
+                from sentence_transformers import SentenceTransformer
+                logger.info(f"Loading embedding model: {self.model_name}")
+                self._model = SentenceTransformer(self.model_name)
+                logger.info(f"Embedding model loaded: dim={self._model.get_sentence_embedding_dimension()}")
+            except Exception as e:
+                logger.error(f"Failed to load embedding model '{self.model_name}': {e}")
+                raise RuntimeError(
+                    f"Cannot load embedding model '{self.model_name}'. "
+                    "Install sentence-transformers: pip install sentence-transformers"
+                ) from e
+        return self._model
+
+    # ── Core embedding ──────────────────────────────────────────────────────
+
+    def embed_text(self, text: str) -> np.ndarray:
+        """Embed a single text string → numpy array (768,)."""
+        return self.model.encode(text, normalize_embeddings=True)
+
+    def embed_texts(self, texts: List[str]) -> np.ndarray:
+        """Embed a batch of texts → numpy array (N, 768)."""
+        return self.model.encode(texts, normalize_embeddings=True, batch_size=32)
+
+    # ── Layer 1: Grounding Verification ─────────────────────────────────────
+
+    def verify_grounding(
+        self,
+        source_span: str,
+        extracted_text: str,
+    ) -> Tuple[float, bool]:
+        """
+        Layer 1 — Extraction-time span verification.
+
+        Computes cosine similarity between the original transcript span
+        and the extracted fact text. If similarity < threshold, the fact
+        is flagged as potentially hallucinated.
+
+        Returns:
+            (cosine_similarity, is_grounded)
+        """
+        vecs = self.embed_texts([source_span, extracted_text])
+        cosine_sim = float(np.dot(vecs[0], vecs[1]))
+        is_grounded = cosine_sim >= self.grounding_threshold
+        return cosine_sim, is_grounded
+
+    # ── Chunk embeddings (for evidence retrieval) ───────────────────────────
+
+    def store_chunk_embedding(
+        self,
+        session_id: str,
+        chunk_id: str,
+        source_type: str,
+        chunk_text: str,
+        embedding: Optional[np.ndarray] = None,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
+    ) -> None:
+        """Persist a chunk embedding to chunk_embeddings table."""
+        if self.db is None:
+            logger.warning("No DB session — skipping chunk embedding storage")
+            return
+
+        if embedding is None:
+            embedding = self.embed_text(chunk_text)
+
+        from app.database.models import ChunkEmbedding
+        record = ChunkEmbedding(
+            session_id=session_id,
+            chunk_id=chunk_id,
+            source_type=source_type,
+            chunk_text=chunk_text,
+            embedding=embedding.tolist(),
+            start_time=start_time,
+            end_time=end_time,
+        )
+        self.db.add(record)
+        self.db.flush()
+
+    def store_chunk_embeddings_batch(
+        self,
+        session_id: str,
+        chunks: List[Dict[str, Any]],
+    ) -> int:
+        """
+        Batch-embed and store chunks. Returns count stored.
+
+        Each chunk dict must have: chunk_id, source, text.
+        Optional: start, end.
+        """
+        if not chunks or self.db is None:
+            return 0
+
+        texts = [c.get("text", "") for c in chunks]
+        embeddings = self.embed_texts(texts)
+
+        from app.database.models import ChunkEmbedding
+        for chunk, emb in zip(chunks, embeddings):
+            record = ChunkEmbedding(
+                session_id=session_id,
+                chunk_id=chunk["chunk_id"],
+                source_type=chunk.get("source", "transcript"),
+                chunk_text=chunk.get("text", ""),
+                embedding=emb.tolist(),
+                start_time=chunk.get("start"),
+                end_time=chunk.get("end"),
+            )
+            self.db.add(record)
+
+        self.db.flush()
+        return len(chunks)
+
+    def search_similar_chunks(
+        self,
+        session_id: str,
+        query_embedding: np.ndarray,
+        top_k: int = 5,
+        threshold: float = 0.5,
+    ) -> List[Dict[str, Any]]:
+        """
+        Layer 2 — Cosine-distance search against chunk_embeddings.
+
+        Returns top-k chunks ordered by cosine similarity (descending).
+        Uses pgvector's <=> (cosine distance) operator.
+        """
+        if self.db is None:
+            return []
+
+        query_list = query_embedding.tolist()
+
+        # pgvector cosine distance: 1 - cosine_similarity
+        # So we ORDER BY distance ASC and filter distance < (1 - threshold)
+        max_distance = 1.0 - threshold
+
+        result = self.db.execute(
+            sql_text("""
+                SELECT chunk_id, source_type, chunk_text, start_time, end_time,
+                       1 - (embedding <=> :query_vec) AS similarity
+                FROM chunk_embeddings
+                WHERE session_id = :session_id
+                  AND (1 - (embedding <=> :query_vec)) >= :threshold
+                ORDER BY embedding <=> :query_vec
+                LIMIT :top_k
+            """),
+            {
+                "query_vec": str(query_list),
+                "session_id": session_id,
+                "threshold": threshold,
+                "top_k": top_k,
+            },
+        )
+
+        return [
+            {
+                "chunk_id": row.chunk_id,
+                "source_type": row.source_type,
+                "chunk_text": row.chunk_text,
+                "start_time": row.start_time,
+                "end_time": row.end_time,
+                "similarity": float(row.similarity),
+            }
+            for row in result
+        ]
+
+    # ── Clinical embeddings (for patient context) ───────────────────────────
+
+    def store_clinical_embedding(
+        self,
+        patient_id: str,
+        session_id: str,
+        fact: Dict[str, Any],
+        embedding: Optional[np.ndarray] = None,
+        record_id: Optional[str] = None,
+        source_span: Optional[str] = None,
+        grounding_score: Optional[float] = None,
+        is_final: bool = False,
+    ) -> None:
+        """
+        Persist a clinical fact embedding.
+
+        Layer 3 — Persistence-time confidence gating:
+        Facts below persistence_floor are stored with is_final=False.
+        """
+        if self.db is None:
+            logger.warning("No DB session — skipping clinical embedding storage")
+            return
+
+        # Build searchable text from fact
+        fact_text = self._fact_to_text(fact)
+        if embedding is None:
+            embedding = self.embed_text(fact_text)
+
+        confidence = fact.get("confidence", 0.5)
+
+        # Layer 3: Confidence gating
+        if confidence < self.persistence_floor:
+            is_final = False
+
+        from app.database.models import ClinicalEmbedding
+        record = ClinicalEmbedding(
+            patient_id=patient_id,
+            session_id=session_id,
+            record_id=record_id,
+            fact_type=fact.get("type", fact.get("fact_type", "unknown")),
+            fact_key=self._fact_to_key(fact),
+            fact_data=fact,
+            embedding=embedding.tolist(),
+            source_span=source_span,
+            grounding_score=grounding_score,
+            confidence=confidence,
+            is_final=is_final,
+        )
+        self.db.add(record)
+        self.db.flush()
+
+    def search_patient_facts(
+        self,
+        patient_id: str,
+        query_embedding: np.ndarray,
+        top_k: int = 10,
+        threshold: float = 0.5,
+        fact_type: Optional[str] = None,
+        only_final: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """
+        Search clinical_embeddings for a patient by vector similarity.
+
+        Used for:
+        - load_patient_context: retrieve prior facts
+        - cross-visit contradiction detection
+        - evidence augmentation
+        """
+        if self.db is None:
+            return []
+
+        query_list = query_embedding.tolist()
+
+        filters = "patient_id = :patient_id AND (1 - (embedding <=> :query_vec)) >= :threshold"
+        params: Dict[str, Any] = {
+            "query_vec": str(query_list),
+            "patient_id": patient_id,
+            "threshold": threshold,
+            "top_k": top_k,
+        }
+
+        if fact_type:
+            filters += " AND fact_type = :fact_type"
+            params["fact_type"] = fact_type
+
+        if only_final:
+            filters += " AND is_final = true"
+
+        result = self.db.execute(
+            sql_text(f"""
+                SELECT id, fact_type, fact_key, fact_data, confidence,
+                       grounding_score, is_final, session_id,
+                       1 - (embedding <=> :query_vec) AS similarity
+                FROM clinical_embeddings
+                WHERE {filters}
+                ORDER BY embedding <=> :query_vec
+                LIMIT :top_k
+            """),
+            params,
+        )
+
+        return [
+            {
+                "id": row.id,
+                "fact_type": row.fact_type,
+                "fact_key": row.fact_key,
+                "fact_data": row.fact_data,
+                "confidence": float(row.confidence) if row.confidence else None,
+                "grounding_score": float(row.grounding_score) if row.grounding_score else None,
+                "is_final": row.is_final,
+                "session_id": row.session_id,
+                "similarity": float(row.similarity),
+            }
+            for row in result
+        ]
+
+    def get_patient_facts_by_type(
+        self,
+        patient_id: str,
+        fact_type: str,
+        only_final: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """Retrieve all facts of a given type for a patient (exact match, no vector search)."""
+        if self.db is None:
+            return []
+
+        from app.database.models import ClinicalEmbedding
+
+        query = (
+            self.db.query(ClinicalEmbedding)
+            .filter(ClinicalEmbedding.patient_id == patient_id)
+            .filter(ClinicalEmbedding.fact_type == fact_type)
+        )
+        if only_final:
+            query = query.filter(ClinicalEmbedding.is_final.is_(True))
+
+        query = query.order_by(ClinicalEmbedding.created_at.desc())
+
+        return [
+            {
+                "fact_type": row.fact_type,
+                "fact_key": row.fact_key,
+                "fact_data": row.fact_data,
+                "confidence": row.confidence,
+                "is_final": row.is_final,
+                "session_id": row.session_id,
+            }
+            for row in query.all()
+        ]
+
+    def get_all_patient_facts(
+        self,
+        patient_id: str,
+        only_final: bool = True,
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Retrieve all facts for a patient, grouped by fact_type."""
+        if self.db is None:
+            return {}
+
+        from app.database.models import ClinicalEmbedding
+
+        query = (
+            self.db.query(ClinicalEmbedding)
+            .filter(ClinicalEmbedding.patient_id == patient_id)
+        )
+        if only_final:
+            query = query.filter(ClinicalEmbedding.is_final.is_(True))
+
+        query = query.order_by(ClinicalEmbedding.fact_type, ClinicalEmbedding.created_at.desc())
+
+        grouped: Dict[str, List[Dict[str, Any]]] = {}
+        for row in query.all():
+            entry = {
+                "fact_key": row.fact_key,
+                "fact_data": row.fact_data,
+                "confidence": row.confidence,
+                "session_id": row.session_id,
+            }
+            grouped.setdefault(row.fact_type, []).append(entry)
+
+        return grouped
+
+    # ── Helpers ─────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _fact_to_text(fact: Dict[str, Any]) -> str:
+        """Convert a fact dict to a searchable text string for embedding."""
+        fact_type = fact.get("type", fact.get("fact_type", ""))
+        value = fact.get("value", "")
+
+        if isinstance(value, dict):
+            parts = [f"{k}: {v}" for k, v in value.items() if v]
+            value_str = ", ".join(parts)
+        elif isinstance(value, list):
+            value_str = ", ".join(str(v) for v in value)
+        else:
+            value_str = str(value)
+
+        return f"{fact_type} {value_str}".strip()
+
+    @staticmethod
+    def _fact_to_key(fact: Dict[str, Any]) -> str:
+        """Extract a canonical key from a fact for deduplication."""
+        value = fact.get("value", "")
+        fact_type = fact.get("type", fact.get("fact_type", "unknown"))
+
+        if isinstance(value, dict):
+            # Use the most identifying field
+            for key in ("name", "substance", "code", "test", "mrn"):
+                if key in value and value[key]:
+                    return str(value[key]).lower().strip()
+            return str(list(value.values())[0]).lower().strip() if value else fact_type
+
+        return str(value).lower().strip() if value else fact_type
+
+
+# ── Singleton (lazy) ────────────────────────────────────────────────────────
+
+_embedding_service: Optional[EmbeddingService] = None
+
+
+def get_embedding_service(db: Optional[DBSession] = None) -> EmbeddingService:
+    """Get or create the singleton EmbeddingService (model loaded once)."""
+    global _embedding_service
+    if _embedding_service is None:
+        _embedding_service = EmbeddingService(db=db)
+    elif db is not None:
+        # Update DB session for the current request
+        _embedding_service.db = db
+    return _embedding_service


### PR DESCRIPTION
…nce retrieval, record fill

- extract_candidates: NLP entity extraction for medications (name, dose, route, frequency), diagnoses (ICD-10), lab values, allergies, procedures; produces typed CandidateFact list with per-fact confidence scores
- retrieve_evidence: pgvector ANN cosine search anchors each CandidateFact to its source utterance or document chunk, populating EvidenceItem list for downstream audit trail and conflict detection
- fill_structured_record: maps CandidateFacts onto typed StructuredRecord Pydantic schema; merges with existing patient history from DB
- record_schema: StructuredRecord, MedicationEntry, DiagnosisEntry field definitions with validation rules and serialisation helpers
- EmbeddingService: async OpenAI/local encoder adapter, batch embed with caching; stores vectors to pgvector via asyncpg bulk insert