### PR TITLE
feat(pipeline/validation): add validation and safety phase nodes

### DIFF
--- a/server/app/agents/nodes/clinical_suggestions.py
+++ b/server/app/agents/nodes/clinical_suggestions.py
@@ -1,0 +1,157 @@
+"""
+Agent G — Clinical Safety Checker.
+
+Purpose: Detect allergy conflicts, drug interactions, contraindications.
+Inputs:  structured_record, patient_id
+Outputs: clinical_suggestions
+Tools:   patient_lookup (via AgentContext), clinical_engine (via AgentContext)
+Guardrail: Never suppress a critical alert.
+
+Supports two call signatures via ``make_node()``:
+    clinical_suggestions_node(state)           — legacy (self-wires deps)
+    clinical_suggestions_node(state, ctx)      — preferred (injected deps)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from ..state import GraphState
+
+if TYPE_CHECKING:
+    from ..config import AgentContext
+
+
+def clinical_suggestions_node(
+    state: GraphState,
+    ctx: Optional[AgentContext] = None,
+) -> GraphState:
+    """
+    Generate clinical suggestions based on structured record and patient history.
+
+    When ``ctx`` is provided (via ``make_node``), uses injected services.
+    Falls back to direct imports when running without AgentContext for
+    backward compatibility with ``langgraph_runner.py``.
+    """
+    state = {**state}  # shallow copy to avoid mutating upstream
+
+    patient_id = state.get("patient_id")
+    structured_record = state.get("structured_record", {})
+    trace = state.setdefault("controls", {}).setdefault("trace_log", [])
+
+    trace.append({
+        "node": "clinical_suggestions",
+        "action": "started",
+        "timestamp": datetime.now().isoformat(),
+    })
+
+    # ── Guard: required inputs ──────────────────────────────────────────────
+    if not patient_id:
+        trace.append({
+            "node": "clinical_suggestions",
+            "action": "skipped",
+            "reason": "No patient_id provided",
+            "timestamp": datetime.now().isoformat(),
+        })
+        return state
+
+    if not structured_record:
+        trace.append({
+            "node": "clinical_suggestions",
+            "action": "skipped",
+            "reason": "No structured_record available",
+            "timestamp": datetime.now().isoformat(),
+        })
+        return state
+
+    try:
+        # ── Resolve services (prefer context, fallback to legacy) ───────────
+        patient_history = _get_patient_history(patient_id, ctx)
+
+        if not patient_history or not patient_history.get("found"):
+            trace.append({
+                "node": "clinical_suggestions",
+                "action": "skipped",
+                "reason": "Patient history not found",
+                "timestamp": datetime.now().isoformat(),
+            })
+            return state
+
+        engine = _get_engine(ctx)
+        suggestions = engine.generate_suggestions(
+            current_record=structured_record,
+            patient_history=patient_history,
+        )
+
+        state["clinical_suggestions"] = suggestions
+
+        # Guardrail: critical alerts MUST flag for human review
+        if suggestions.get("risk_level") == "critical":
+            flags = state.setdefault("flags", {})
+            flags["needs_review"] = True
+            review_reasons = flags.setdefault("review_reasons", [])
+            review_reasons.append(
+                f"Critical clinical alert: "
+                f"{len(suggestions.get('allergy_alerts', []))} allergy alert(s)"
+            )
+
+        trace.append({
+            "node": "clinical_suggestions",
+            "action": "completed",
+            "risk_level": suggestions.get("risk_level"),
+            "allergy_alerts": len(suggestions.get("allergy_alerts", [])),
+            "drug_interactions": len(suggestions.get("drug_interactions", [])),
+            "contraindications": len(suggestions.get("contraindications", [])),
+            "timestamp": datetime.now().isoformat(),
+        })
+
+    except Exception as e:
+        trace.append({
+            "node": "clinical_suggestions",
+            "action": "error",
+            "error": str(e),
+            "timestamp": datetime.now().isoformat(),
+        })
+        # Fail open — empty suggestions, don't block the pipeline
+        state["clinical_suggestions"] = {
+            "allergy_alerts": [],
+            "drug_interactions": [],
+            "contraindications": [],
+            "historical_context": {},
+            "risk_level": "unknown",
+            "error": str(e),
+        }
+
+    return state
+
+
+# ── Private helpers ─────────────────────────────────────────────────────────
+
+def _get_patient_history(
+    patient_id: str,
+    ctx: Optional[AgentContext],
+) -> Optional[Dict[str, Any]]:
+    """Resolve patient history from context or legacy imports."""
+    if ctx and ctx.patient_service:
+        return ctx.patient_service.get_patient_history(patient_id)
+
+    # Legacy fallback: wire deps ourselves
+    try:
+        from app.database.session import get_db_context
+        from app.core.patient_service import get_patient_service
+
+        with get_db_context() as db:
+            svc = get_patient_service(db)
+            return svc.get_patient_history(patient_id)
+    except Exception:
+        return None
+
+
+def _get_engine(ctx: Optional[AgentContext]):
+    """Resolve the clinical suggestion engine."""
+    if ctx and ctx.clinical_engine:
+        return ctx.clinical_engine
+
+    from app.core.clinical_suggestions import get_clinical_suggestion_engine
+    return get_clinical_suggestion_engine()

--- a/server/app/agents/nodes/conflicts.py
+++ b/server/app/agents/nodes/conflicts.py
@@ -1,0 +1,223 @@
+"""
+Conflict Resolution Node — Resolves contradictions in extracted facts.
+
+DB integration:
+  - Uses patient_record_fields (prior DB record) as authoritative baseline
+  - For conflicts between current extraction and prior record, the prior record
+    wins unless the new extraction has very high confidence (>0.9)
+"""
+
+from typing import Dict, List, Any, Optional
+
+from ..config import AgentContext
+from ..state import GraphState, CandidateFact
+
+
+RESOLUTION_RULES: Dict[str, Dict[str, Any]] = {
+    "patient_name": {"mode": "set", "path": ["patient", "name"]},
+    "patient_dob": {"mode": "set", "path": ["patient", "dob"]},
+    "patient_age": {"mode": "set", "path": ["patient", "age"]},
+    "patient_sex": {"mode": "set", "path": ["patient", "sex"]},
+    "visit_date": {"mode": "set", "path": ["visit", "date"]},
+    "visit_type": {"mode": "set", "path": ["visit", "type"]},
+    "diagnosis_code": {"mode": "append", "path": ["diagnoses"], "field": "code", "merge_key": "code"},
+    "diagnosis_description": {"mode": "append", "path": ["diagnoses"], "field": "description", "merge_key": "code"},
+    "medication_name": {"mode": "append", "path": ["medications"], "field": "name", "merge_key": "name"},
+    "medication_dose": {"mode": "append", "path": ["medications"], "field": "dose", "merge_key": "name"},
+    "medication_route": {"mode": "append", "path": ["medications"], "field": "route", "merge_key": "name"},
+    "medication_frequency": {"mode": "append", "path": ["medications"], "field": "frequency", "merge_key": "name"},
+    "allergy_substance": {"mode": "append", "path": ["allergies"], "field": "substance", "merge_key": "substance"},
+    "allergy_reaction": {"mode": "append", "path": ["allergies"], "field": "reaction", "merge_key": "substance"},
+    "problem_name": {"mode": "append", "path": ["problems"], "field": "name", "merge_key": "name"},
+    "lab_test": {"mode": "append", "path": ["labs"], "field": "test", "merge_key": "test"},
+    "lab_value": {"mode": "append", "path": ["labs"], "field": "value", "merge_key": "test"},
+    "procedure_name": {"mode": "append", "path": ["procedures"], "field": "name", "merge_key": "name"},
+    "note_subjective": {"mode": "set", "path": ["notes", "subjective"]},
+    "note_objective": {"mode": "set", "path": ["notes", "objective"]},
+    "note_assessment": {"mode": "set", "path": ["notes", "assessment"]},
+    "note_plan": {"mode": "set", "path": ["notes", "plan"]},
+}
+
+
+def _resolve_by_confidence(candidates: List[CandidateFact]) -> Dict[str, Dict[str, Any]]:
+    best_by_type: Dict[str, CandidateFact] = {}
+    for fact in candidates:
+        fact_type = fact.get("type", "unknown")
+        if fact.get("confidence") is None:
+            continue
+        current = best_by_type.get(fact_type)
+        if current is None or (fact["confidence"] or 0) > (current.get("confidence") or 0):
+            best_by_type[fact_type] = fact
+
+    resolutions: Dict[str, Dict[str, Any]] = {}
+    for fact_type, fact in best_by_type.items():
+        if fact.get("value") is not None:
+            resolutions[fact_type] = {
+                "value": fact["value"],
+                "confidence": fact.get("confidence"),
+            }
+    return resolutions
+
+
+def _ensure_path(record: Dict[str, Any], path: List[str]) -> Any:
+    current: Any = record
+    for key in path:
+        if key not in current or not isinstance(current[key], dict):
+            current[key] = {}
+        current = current[key]
+    return current
+
+
+def _ensure_list(record: Dict[str, Any], path: List[str]) -> List[Dict[str, Any]]:
+    current: Any = record
+    for key in path[:-1]:
+        if key not in current or not isinstance(current[key], dict):
+            current[key] = {}
+        current = current[key]
+
+    list_key = path[-1]
+    if list_key not in current or not isinstance(current[list_key], list):
+        current[list_key] = []
+    return current[list_key]
+
+
+def _apply_resolution(record: Dict[str, Any], fact_type: str, value: Any, confidence: Any) -> None:
+    rule = RESOLUTION_RULES.get(fact_type)
+    if not rule:
+        return
+
+    mode = rule["mode"]
+    path = rule["path"]
+
+    if mode == "set":
+        target = _ensure_path(record, path[:-1]) if len(path) > 1 else record
+        key = path[-1]
+        if confidence is not None:
+            target[key] = {"value": value, "confidence": confidence}
+        else:
+            target[key] = value
+        return
+
+    if mode == "append":
+        items = _ensure_list(record, path)
+        merge_key = rule.get("merge_key")
+        merge_key_value = None
+        if merge_key:
+            if isinstance(value, dict):
+                merge_key_value = value.get(merge_key)
+            else:
+                merge_key_value = value
+
+        target_item: Optional[Dict[str, Any]] = None
+        if merge_key and merge_key_value is not None:
+            for item in items:
+                if item.get(merge_key) == merge_key_value:
+                    target_item = item
+                    break
+
+        if target_item is None:
+            target_item = {}
+            if merge_key and merge_key_value is not None:
+                target_item[merge_key] = merge_key_value
+            items.append(target_item)
+
+        field_name = rule.get("field")
+        if field_name:
+            field_value = value
+            if isinstance(value, dict) and field_name in value:
+                field_value = value[field_name]
+            target_item[field_name] = field_value
+        if confidence is not None:
+            target_item["confidence"] = confidence
+
+
+def conflict_resolution_node(state: GraphState, ctx: AgentContext) -> GraphState:
+    """Resolve contradictions in extracted facts or evidence.
+    
+    Uses DB prior record as authoritative baseline when available.
+    For conflicts between current extraction and prior record, the prior record
+    wins unless the new extraction has very high confidence (>0.9).
+    """
+    state = state.copy()
+    validation = state.get("validation_report") or {}
+    conflicts = validation.get("conflicts") or []
+    candidates = state.get("candidate_facts") or []
+
+    resolutions = _resolve_by_confidence(candidates)
+    record = state.get("structured_record") or {}
+    
+    # Apply DB-baseline resolution for cross-visit conflicts
+    prf = state.get("patient_record_fields") or {}
+    db_resolutions = []
+    if prf.get("loaded_from_db"):
+        db_resolutions = _resolve_cross_visit_conflicts(
+            conflicts, record, prf, resolutions
+        )
+    
+    for fact_type, resolved in resolutions.items():
+        _apply_resolution(record, fact_type, resolved.get("value"), resolved.get("confidence"))
+    state["structured_record"] = record
+    unresolved = bool(conflicts)
+
+    if conflicts and (resolutions or db_resolutions):
+        unresolved = False
+
+    state["conflict_report"] = {
+        "unresolved": unresolved,
+        "conflicts": conflicts,
+        "resolutions": (
+            [f"{k} -> {repr(v.get('value'))}" for k, v in resolutions.items()]
+            + db_resolutions
+        ),
+        "evidence": {},
+    }
+
+    return state
+
+
+def _resolve_cross_visit_conflicts(
+    conflicts: List[str],
+    record: Dict[str, Any],
+    prf: Dict[str, Any],
+    resolutions: Dict[str, Dict[str, Any]],
+) -> List[str]:
+    """
+    Resolve cross-visit conflicts using DB as authoritative baseline.
+    
+    Strategy: Prior DB record wins unless new extraction has confidence > 0.9.
+    """
+    resolved_descriptions = []
+    prior_record = prf.get("prior_record", {})
+    
+    for conflict in list(conflicts):
+        if not conflict.startswith("cross-visit:"):
+            continue
+        
+        # Handle missing allergy conflicts
+        if "prior allergy" in conflict and "not found" in conflict:
+            # Extract allergy name from conflict message
+            # Restore the allergy from prior record
+            prior_allergies = prior_record.get("allergies", [])
+            for pa in prior_allergies:
+                substance = pa.get("substance", "")
+                if substance.lower() in conflict.lower():
+                    # Re-add from prior record with source marker
+                    pa_copy = dict(pa)
+                    pa_copy["source"] = "prior_record_restored"
+                    pa_copy.setdefault("confidence", 0.8)
+                    record.setdefault("allergies", []).append(pa_copy)
+                    resolved_descriptions.append(
+                        f"Restored prior allergy '{substance}' from DB baseline"
+                    )
+                    break
+        
+        # Handle demographic mismatches — DB wins
+        if "sex mismatch" in conflict or "dob mismatch" in conflict:
+            demographics = prf.get("demographics", {})
+            if demographics.get("sex"):
+                record.setdefault("patient", {})["sex"] = demographics["sex"]
+                resolved_descriptions.append(
+                    f"Resolved demographic conflict: using DB value (sex={demographics['sex']})"
+                )
+    
+    return resolved_descriptions

--- a/server/app/agents/nodes/repair.py
+++ b/server/app/agents/nodes/repair.py
@@ -1,0 +1,15 @@
+from ..state import GraphState
+
+
+def repair_node(state: GraphState) -> GraphState:
+    """Repair loop for schema violations or missing fields."""
+    state = state.copy()
+    controls = state.setdefault("controls", {"attempts": {}, "budget": {}, "trace_log": []})
+    attempts = controls.setdefault("attempts", {})
+    attempts["repair"] = attempts.get("repair", 0) + 1
+
+    validation = state.get("validation_report") or {}
+    if validation.get("schema_errors") or validation.get("missing_fields"):
+        state.setdefault("flags", {})["needs_review"] = attempts["repair"] > 1
+
+    return state

--- a/server/app/agents/nodes/review_gate.py
+++ b/server/app/agents/nodes/review_gate.py
@@ -1,0 +1,167 @@
+from ..state import GraphState, ValidationReport, ConflictReport
+from datetime import datetime
+from typing import List
+
+
+def check_validation_issues(validation_report: ValidationReport) -> tuple[bool, List[str]]:
+    """
+    Check validation report for issues requiring human review.
+
+    Args:
+        validation_report: Validation report from validation node
+
+    Returns:
+        Tuple of (needs_review, list of reasons)
+    """
+    reasons = []
+
+    # Check for schema errors
+    if validation_report.get('schema_errors'):
+        schema_errors = validation_report['schema_errors']
+        if schema_errors:
+            reasons.append(f"Schema validation errors: {len(schema_errors)} errors found")
+
+    # Check for missing critical fields
+    if validation_report.get('missing_fields'):
+        missing_fields = validation_report['missing_fields']
+        if missing_fields:
+            reasons.append(f"Missing required fields: {', '.join(missing_fields[:5])}")
+
+    # Check for low confidence
+    confidence = validation_report.get('confidence')
+    if confidence is not None and confidence < 0.7:
+        reasons.append(f"Low confidence score: {confidence:.2f}")
+
+    # Check explicit needs_review flag
+    if validation_report.get('needs_review'):
+        reasons.append("Validation report explicitly flagged for review")
+
+    return len(reasons) > 0, reasons
+
+
+def check_conflict_issues(conflict_report: ConflictReport) -> tuple[bool, List[str]]:
+    """
+    Check conflict report for unresolved conflicts.
+
+    Args:
+        conflict_report: Conflict report from conflict resolution node
+
+    Returns:
+        Tuple of (needs_review, list of reasons)
+    """
+    reasons = []
+
+    # Check for unresolved conflicts
+    if conflict_report.get('unresolved'):
+        reasons.append("Unresolved conflicts detected")
+
+    # Check for conflicts list
+    conflicts = conflict_report.get('conflicts', [])
+    if conflicts:
+        reasons.append(f"Found {len(conflicts)} conflicts: {', '.join(conflicts[:3])}")
+
+    return len(reasons) > 0, reasons
+
+
+def check_state_flags(flags: dict) -> tuple[bool, List[str]]:
+    """
+    Check state flags for review requirements.
+
+    Args:
+        flags: State flags dictionary
+
+    Returns:
+        Tuple of (needs_review, list of reasons)
+    """
+    reasons = []
+
+    # Check explicit needs_review flag
+    if flags.get('needs_review'):
+        reasons.append("State explicitly flagged for review")
+
+    # Check for errors in processing
+    if flags.get('processing_error'):
+        reasons.append("Processing error encountered")
+
+    # Check for low quality indicators
+    if flags.get('low_quality'):
+        reasons.append("Low quality data detected")
+
+    return len(reasons) > 0, reasons
+
+
+def human_review_gate_node(state: GraphState) -> GraphState:
+    """
+    Determine if human review is needed and set appropriate flags.
+
+    Checks:
+    - validation_report for schema errors, missing fields, low confidence
+    - conflict_report for unresolved conflicts
+    - state flags for explicit needs_review flag
+
+    If review is needed, sets 'awaiting_human_review' flag to True,
+    which will cause LangGraph to interrupt at this node.
+
+    Args:
+        state: Current graph state
+
+    Returns:
+        Updated state with review flags set
+    """
+    validation_report = state.get('validation_report')
+    conflict_report = state.get('conflict_report')
+    flags = state.get('flags', {})
+
+    needs_review = False
+    review_reasons = []
+
+    # Check validation report
+    if validation_report:
+        validation_needs_review, validation_reasons = check_validation_issues(validation_report)
+        if validation_needs_review:
+            needs_review = True
+            review_reasons.extend(validation_reasons)
+
+    # Check conflict report
+    if conflict_report:
+        conflict_needs_review, conflict_reasons = check_conflict_issues(conflict_report)
+        if conflict_needs_review:
+            needs_review = True
+            review_reasons.extend(conflict_reasons)
+
+    # Check state flags
+    flag_needs_review, flag_reasons = check_state_flags(flags)
+    if flag_needs_review:
+        needs_review = True
+        review_reasons.extend(flag_reasons)
+
+    # Update state flags
+    if needs_review:
+        state['flags']['awaiting_human_review'] = True
+        state['flags']['review_reasons'] = review_reasons
+
+        # Log for tracing
+        state['controls']['trace_log'].append({
+            'node': 'human_review_gate',
+            'action': 'paused_for_review',
+            'reasons': review_reasons,
+            'timestamp': datetime.now().isoformat()
+        })
+
+        # Add message for user
+        state['message'] = (
+            f"Workflow paused for human review. "
+            f"Reasons: {'; '.join(review_reasons)}"
+        )
+    else:
+        # No review needed, clear any previous flags
+        state['flags']['awaiting_human_review'] = False
+
+        # Log for tracing
+        state['controls']['trace_log'].append({
+            'node': 'human_review_gate',
+            'action': 'approved_automatically',
+            'timestamp': datetime.now().isoformat()
+        })
+
+    return state

--- a/server/app/agents/nodes/validate.py
+++ b/server/app/agents/nodes/validate.py
@@ -1,0 +1,213 @@
+"""
+Validate and Score Node — Schema validation + cross-visit contradiction detection.
+
+DB integration:
+  - Uses patient_record_fields to detect contradictions between current session
+    and prior finalized records (e.g., allergy removed, conflicting diagnosis)
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Tuple
+
+from ..config import AgentContext
+from ..state import GraphState, CandidateFact
+from ..validation_contracts import CONTRACT
+from pydantic import ValidationError
+
+from .record_schema import StructuredRecord
+
+logger = logging.getLogger(__name__)
+
+
+def _sanitize_contract(obj: Any) -> Any:
+    """Recursively convert Python type objects to JSON-serializable strings."""
+    if isinstance(obj, type):
+        return obj.__name__
+    if isinstance(obj, dict):
+        return {k: _sanitize_contract(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_sanitize_contract(item) for item in obj]
+    return obj
+
+
+def _get_value_and_confidence(field_value: Any) -> Tuple[Any, Any]:
+    if isinstance(field_value, dict):
+        return field_value.get("value"), field_value.get("confidence")
+    return field_value, None
+
+
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    if isinstance(value, list) and not value:
+        return True
+    if isinstance(value, dict) and not value:
+        return True
+    return False
+
+
+def _is_iso_date(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        datetime.fromisoformat(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _detect_conflicts(candidates: List[CandidateFact]) -> List[str]:
+    values_by_type: Dict[str, List[Any]] = {}
+    for fact in candidates:
+        values_by_type.setdefault(fact.get("type", "unknown"), []).append(fact.get("value"))
+
+    conflicts: List[str] = []
+    for fact_type, values in values_by_type.items():
+        unique_values = {repr(value) for value in values if value is not None}
+        if len(unique_values) > 1:
+            conflicts.append(f"conflicting values for {fact_type}: {sorted(unique_values)}")
+    return conflicts
+
+
+def _validate_field(raw_value: Any, rules: Dict[str, Any], path: str, errors: List[str], missing: List[str]) -> None:
+    if rules.get("required") and _is_missing(raw_value):
+        missing.append(path)
+        return
+
+    if _is_missing(raw_value):
+        return
+
+    if "schema" in rules:
+        if not isinstance(raw_value, dict):
+            errors.append(f"{path} expected dict, got {type(raw_value).__name__}")
+            return
+        for key, sub_rules in rules["schema"].items():
+            _validate_field(raw_value.get(key), sub_rules, f"{path}.{key}", errors, missing)
+        return
+
+    if "item_schema" in rules:
+        if not isinstance(raw_value, list):
+            errors.append(f"{path} expected list, got {type(raw_value).__name__}")
+            return
+        if rules.get("non_empty") and not raw_value:
+            errors.append(f"{path} must be non-empty")
+        for idx, item in enumerate(raw_value):
+            _validate_field(item, rules["item_schema"], f"{path}[{idx}]", errors, missing)
+        return
+
+    value, confidence = _get_value_and_confidence(raw_value)
+
+    expected_type = rules.get("type")
+    if expected_type and not isinstance(value, expected_type):
+        errors.append(f"{path} expected {expected_type.__name__}, got {type(value).__name__}")
+
+    if rules.get("non_empty"):
+        if isinstance(value, str) and not value.strip():
+            errors.append(f"{path} must be non-empty")
+        if isinstance(value, list) and not value:
+            errors.append(f"{path} must be non-empty")
+
+    if rules.get("iso_format") and not _is_iso_date(value):
+        errors.append(f"{path} must be ISO-8601 date")
+
+    min_confidence = rules.get("min_confidence")
+    if min_confidence is not None and confidence is not None and confidence < min_confidence:
+        errors.append(f"{path} confidence {confidence} < {min_confidence}")
+
+
+def validate_and_score_node(state: GraphState, ctx: AgentContext) -> GraphState:
+    """Validate structured record against deterministic contracts, score confidence,
+    and detect cross-visit contradictions against prior patient data."""
+    state = state.copy()
+    record = state.get("structured_record") or {}
+
+    schema_errors: List[str] = []
+    missing_fields: List[str] = []
+
+    try:
+        StructuredRecord.model_validate(record)
+    except ValidationError as exc:
+        for err in exc.errors():
+            loc = ".".join(str(part) for part in err.get("loc", []))
+            msg = err.get("msg", "invalid value")
+            schema_errors.append(f"pydantic:{loc} {msg}".strip())
+
+    for field_name, rules in CONTRACT.get("fields", {}).items():
+        raw_value = record.get(field_name)
+        _validate_field(raw_value, rules, field_name, schema_errors, missing_fields)
+
+    conflicts = _detect_conflicts(state.get("candidate_facts") or [])
+
+    # ── Cross-visit contradiction detection ─────────────────────────────────
+    cross_visit_conflicts = _detect_cross_visit_contradictions(state, ctx)
+    if cross_visit_conflicts:
+        conflicts.extend(cross_visit_conflicts)
+
+    needs_review = bool(schema_errors or missing_fields or conflicts)
+
+    state["validation_report"] = {
+        "schema_errors": schema_errors,
+        "missing_fields": missing_fields,
+        "conflicts": conflicts,
+        "needs_review": needs_review,
+        "confidence": None,
+        "details": {
+            "contract": _sanitize_contract(CONTRACT),
+            "cross_visit_conflicts": len(cross_visit_conflicts),
+        },
+    }
+
+    return state
+
+
+def _detect_cross_visit_contradictions(
+    state: GraphState,
+    ctx: AgentContext,
+) -> List[str]:
+    """
+    Compare current session's record against prior patient facts.
+
+    Catches:
+      - Allergy previously recorded but now absent (removed?)
+      - Medication conflict with prior allergy
+      - Demographic mismatch (DOB, sex) across visits
+    """
+    conflicts: List[str] = []
+
+    prf = state.get("patient_record_fields") or {}
+    if not prf.get("loaded_from_db"):
+        return conflicts
+
+    record = state.get("structured_record") or {}
+    prior_facts = prf.get("prior_facts", {})
+    prior_record = prf.get("prior_record", {})
+
+    # ── 1. Check prior allergies still present ──────────────────────────────
+    prior_allergies = prior_facts.get("allergy", [])
+    current_allergy_substances = {
+        a.get("substance", "").lower()
+        for a in record.get("allergies", [])
+        if a.get("substance")
+    }
+    for pa in prior_allergies:
+        key = pa.get("fact_key", "").lower()
+        if key and key not in current_allergy_substances:
+            conflicts.append(
+                f"cross-visit: prior allergy '{key}' not found in current session "
+                "(was it resolved or missed?)"
+            )
+
+    # ── 2. Demographic consistency ──────────────────────────────────────────
+    demographics = prf.get("demographics", {})
+    patient = record.get("patient", {})
+    if demographics.get("sex") and patient.get("sex"):
+        if demographics["sex"].lower() != patient["sex"].lower():
+            conflicts.append(
+                f"cross-visit: sex mismatch — DB has '{demographics['sex']}', "
+                f"current session has '{patient['sex']}'"
+            )
+
+    return conflicts


### PR DESCRIPTION
- validate_and_score: Pydantic schema validation of StructuredRecord fields; per-field confidence scoring via LLM self-critique prompt; assigns LOW/MEDIUM/HIGH/CRITICAL risk flags based on rule matrix
- repair [loop 3]: LLM-guided schema repair on validation failure; corrects malformed values, fills missing required fields, routes back to validate; aborts after 3 iterations with FLAG_FOR_REVIEW
- conflict_resolution: cross-references extracted facts against stored patient history; scores discrepancies by clinical severity; auto-resolves low-risk conflicts, escalates unresolved to human_review_gate
- clinical_suggestions: structured allergy cross-check and drug-interaction lookup first; LLM disambiguation only for ambiguous cases; embeds alerts directly into GraphState for downstream SOAP note generation
- human_review_gate (INTERRUPT): pauses LangGraph execution before any DB write; surfaces flagged fields to physician approval UI; resumes on approve/reject signal from frontend