### PR TITLE
feat(pipeline/output): add output phase nodes  SOAP note generation, …

### DIFF
--- a/server/app/agents/nodes/export.py
+++ b/server/app/agents/nodes/export.py
@@ -1,0 +1,189 @@
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return "N/A"
+    if isinstance(value, dict):
+        parts = []
+        for key, val in value.items():
+            if key == "confidence":
+                continue
+            parts.append(f"{key}: {val}")
+        return ", ".join(parts) if parts else "N/A"
+    if isinstance(value, list):
+        return "; ".join(_format_value(item) for item in value) or "N/A"
+    return str(value)
+
+
+def _build_structured_rows(record: Dict[str, Any]) -> List[List[str]]:
+    rows: List[List[str]] = [["Section", "Field", "Value"]]
+
+    def add_section(title: str) -> None:
+        rows.append([title, "", ""])
+
+    def add_field(section: str, field: str, value: Any) -> None:
+        rows.append([section, field, _format_value(value)])
+
+    patient = record.get("patient", {})
+    visit = record.get("visit", {})
+    diagnoses = record.get("diagnoses", [])
+    medications = record.get("medications", [])
+    allergies = record.get("allergies", [])
+
+    add_section("Patient Demographics")
+    for key in ("name", "dob", "age", "sex", "mrn"):
+        if key in patient:
+            add_field("Patient", key.replace("_", " ").title(), patient.get(key))
+
+    add_section("Visit Details")
+    for key in ("date", "type", "location", "provider"):
+        if key in visit:
+            add_field("Visit", key.replace("_", " ").title(), visit.get(key))
+
+    add_section("Diagnoses")
+    if diagnoses:
+        for item in diagnoses:
+            code = item.get("code") if isinstance(item, dict) else item
+            add_field("Diagnoses", "Code", code)
+            if isinstance(item, dict) and item.get("description"):
+                add_field("Diagnoses", "Description", item.get("description"))
+    else:
+        add_field("Diagnoses", "Code", "N/A")
+
+    add_section("Medications")
+    if medications:
+        for item in medications:
+            add_field("Medications", "Name", item.get("name") if isinstance(item, dict) else item)
+            if isinstance(item, dict):
+                for key in ("dose", "route", "frequency"):
+                    if item.get(key):
+                        add_field("Medications", key.title(), item.get(key))
+    else:
+        add_field("Medications", "Name", "N/A")
+
+    add_section("Allergies")
+    if allergies:
+        for item in allergies:
+            add_field("Allergies", "Substance", item.get("substance") if isinstance(item, dict) else item)
+            if isinstance(item, dict) and item.get("reaction"):
+                add_field("Allergies", "Reaction", item.get("reaction"))
+    else:
+        add_field("Allergies", "Substance", "N/A")
+
+    return rows
+
+
+def write_report_pdf(
+    output_path: Path,
+    title: str,
+    meta: List[Tuple[str, str]],
+    summary_text: str,
+    clinical_note: str,
+    structured_record: Dict[str, Any],
+    validation_report: Dict[str, Any],
+    conflict_report: Dict[str, Any],
+) -> None:
+    try:
+        from reportlab.lib import colors
+        from reportlab.lib.pagesizes import LETTER
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.lib.units import inch
+        from reportlab.platypus import (
+            Paragraph,
+            Preformatted,
+            SimpleDocTemplate,
+            Spacer,
+            Table,
+            TableStyle,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "reportlab is not available. Install reportlab to enable PDF export."
+        ) from exc
+
+    styles = getSampleStyleSheet()
+    title_style = ParagraphStyle(
+        "Title",
+        parent=styles["Title"],
+        textColor=colors.white,
+        backColor=colors.HexColor("#577aa6"),
+        alignment=1,
+        padding=6,
+    )
+    section_style = ParagraphStyle(
+        "Section",
+        parent=styles["Heading2"],
+        textColor=colors.HexColor("#2f3a4a"),
+        spaceBefore=12,
+        spaceAfter=6,
+    )
+    pre_style = ParagraphStyle(
+        "Preformatted",
+        parent=styles["BodyText"],
+        fontName="Courier",
+        fontSize=8.5,
+        leading=10.5,
+    )
+
+    doc = SimpleDocTemplate(
+        str(output_path),
+        pagesize=LETTER,
+        leftMargin=0.6 * inch,
+        rightMargin=0.6 * inch,
+        topMargin=0.6 * inch,
+        bottomMargin=0.6 * inch,
+    )
+
+    story: List[Any] = [Paragraph(title, title_style), Spacer(1, 0.2 * inch)]
+
+    if meta:
+        meta_table = Table([[k, v] for k, v in meta], colWidths=[1.5 * inch, 4.8 * inch])
+        meta_table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (0, -1), colors.HexColor("#c7d2e0")),
+                    ("TEXTCOLOR", (0, 0), (0, -1), colors.HexColor("#1f2937")),
+                    ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#94a3b8")),
+                    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ]
+            )
+        )
+        story.extend([meta_table, Spacer(1, 0.2 * inch)])
+
+    story.append(Paragraph("Session Summary", section_style))
+    story.append(Preformatted(summary_text or "N/A", pre_style))
+    story.append(Spacer(1, 0.15 * inch))
+
+    story.append(Paragraph("Clinical Note", section_style))
+    story.append(Preformatted(clinical_note or "N/A", pre_style))
+    story.append(Spacer(1, 0.15 * inch))
+
+    story.append(Paragraph("Structured Record", section_style))
+    rows = _build_structured_rows(structured_record)
+    table = Table(rows, colWidths=[1.6 * inch, 1.6 * inch, 3.2 * inch])
+    table_style = TableStyle(
+        [
+            ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#577aa6")),
+            ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#94a3b8")),
+            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ]
+    )
+    for idx in range(1, len(rows)):
+        if rows[idx][1] == "" and rows[idx][2] == "":
+            table_style.add("BACKGROUND", (0, idx), (-1, idx), colors.HexColor("#d3dbea"))
+            table_style.add("FONTNAME", (0, idx), (-1, idx), "Helvetica-Bold")
+    table.setStyle(table_style)
+    story.extend([table, Spacer(1, 0.15 * inch)])
+
+    story.append(Paragraph("Validation Report", section_style))
+    story.append(Preformatted(_format_value(validation_report), pre_style))
+    story.append(Spacer(1, 0.15 * inch))
+
+    story.append(Paragraph("Conflict Report", section_style))
+    story.append(Preformatted(_format_value(conflict_report), pre_style))
+
+    doc.build(story)

--- a/server/app/agents/nodes/generate_note.py
+++ b/server/app/agents/nodes/generate_note.py
@@ -1,0 +1,327 @@
+"""
+Agent H — Note Generator (Grounded)
+
+Purpose: Produce human-readable clinical note grounded in structured record.
+Hard constraint: No new entities not present in record. SOAP/H&P format.
+Tools: LLM summarizer with strict grounding ("use only provided JSON")
+
+DB integration:
+  - Includes patient history context (visit count, prior problems) in prompt
+  - Flags facts with low grounding scores
+"""
+
+import json
+from typing import Dict, Any, Optional
+from ..config import AgentContext
+from ..state import GraphState
+from ...models.llm import LLMClient
+
+
+def generate_note_node(state: GraphState, ctx: AgentContext) -> GraphState:
+    """
+    Generate clinical note from structured record only (no hallucinating).
+    
+    Agent H: Note Generator
+    - Produces SOAP (Subjective/Objective/Assessment/Plan) format note
+    - Grounded ONLY in structured_record (no access to raw transcripts)
+    - Includes patient history context paragraph (visit count, prior facts)
+    - Includes warnings/conflicts section if present
+    - LLM constrained to not add concepts not in record
+    """
+    state = state.copy() if isinstance(state, dict) else state
+    
+    record = state.get("structured_record", {})
+    validation = state.get("validation_report", {})
+    conflicts = state.get("conflict_report", {})
+    
+    if not record or not record.get("patient"):
+        state["clinical_note"] = "Unable to generate note: No patient data available."
+        return state
+    
+    # Check budget
+    controls = state.get("controls", {"attempts": {}, "budget": {}})
+    budget = controls.get("budget", {})
+    max_llm_calls = budget.get("max_total_llm_calls", ctx.max_llm_calls if ctx else 30)
+    llm_calls_used = budget.get("llm_calls_used", 0)
+    
+    if llm_calls_used >= max_llm_calls:
+        state["clinical_note"] = _generate_template_note(record, validation, conflicts)
+        print("[Generate Note] Budget exhausted, using template-based note")
+        return state
+    
+    # Generate note using LLM with strict grounding
+    try:
+        llm = LLMClient()
+        llm_calls_used += 1
+        
+        # Build patient history context for the note
+        history_context = _build_history_context(state)
+        
+        note = _generate_llm_note(llm, record, validation, conflicts, history_context)
+        state["clinical_note"] = note
+        
+        # Update budget
+        budget["llm_calls_used"] = llm_calls_used
+        controls["budget"] = budget
+        state["controls"] = controls
+        
+        print(f"[Generate Note] Created SOAP note ({len(note)} chars, LLM calls: {llm_calls_used}/{max_llm_calls})")
+        
+    except Exception as e:
+        print(f"[Generate Note] Error: {e}")
+        state["clinical_note"] = _generate_template_note(record, validation, conflicts)
+        print("[Generate Note] Using template-based note as fallback")
+    
+    # Track node execution
+    controls["attempts"]["generate_note"] = \
+        controls.get("attempts", {}).get("generate_note", 0) + 1
+    
+    return state
+
+
+def _generate_llm_note(llm: LLMClient, record: Dict, validation: Dict, 
+                       conflicts: Dict, history_context: str = "") -> str:
+    """Generate note using LLM with strict grounding constraints."""
+    
+    # Serialize record to JSON for grounding
+    record_json = json.dumps(record, indent=2, default=str)
+    
+    prompt = f"""You are a medical documentation assistant. Generate a clinical note in SOAP format.
+
+CRITICAL CONSTRAINTS:
+1. Use ONLY information from the provided JSON record
+2. Do NOT add any clinical facts not present in the record
+3. Do NOT infer diagnoses or treatments not explicitly stated
+4. If information is missing, state "Not documented" rather than inventing
+5. Include confidence warnings for low-confidence fields
+"""
+
+    if history_context:
+        prompt += f"""
+PATIENT HISTORY CONTEXT:
+{history_context}
+Include a brief "History" section at the top of the note summarizing relevant prior visits.
+"""
+
+    prompt += f"""
+Format: SOAP Note
+- Subjective: Patient reported symptoms/history
+- Objective: Vitals, labs, physical findings
+- Assessment: Diagnoses and clinical interpretation
+- Plan: Medications, procedures, follow-up
+
+Structured Record (USE ONLY THIS DATA):
+{record_json}
+
+Generate a professional SOAP note using ONLY the above data:"""
+    
+    response = llm.generate_response(prompt)
+    
+    # Add warnings section if there are validation issues or conflicts
+    warnings = []
+    if validation.get("schema_errors"):
+        warnings.append(f"⚠ Validation Issues: {len(validation['schema_errors'])} errors detected")
+    if validation.get("needs_review"):
+        warnings.append("⚠ This record requires clinical review")
+    if conflicts.get("conflicts"):
+        warnings.append(f"⚠ Conflicts Detected: {len(conflicts.get('conflicts', []))} unresolved")
+    
+    if warnings:
+        response += "\n\n--- SYSTEM WARNINGS ---\n" + "\n".join(warnings)
+    
+    return response
+
+
+def _generate_template_note(record: Dict, validation: Dict, conflicts: Dict) -> str:
+    """Generate deterministic template-based note (no LLM)."""
+    
+    patient = record.get("patient", {})
+    allergies = record.get("allergies", [])
+    medications = record.get("medications", [])
+    diagnoses = record.get("diagnoses", [])
+    vitals = record.get("vitals", [])
+    labs = record.get("labs", [])
+    procedures = record.get("procedures", [])
+    followups = record.get("followups", [])
+    
+    lines = []
+    lines.append("CLINICAL NOTE")
+    lines.append("=" * 60)
+    lines.append("")
+    
+    # Header
+    lines.append("PATIENT INFORMATION")
+    lines.append(f"Name: {patient.get('name', 'Not documented')}")
+    lines.append(f"DOB: {patient.get('dob', 'Not documented')}")
+    lines.append(f"Age: {patient.get('age', 'Not documented')}")
+    lines.append(f"Sex: {patient.get('sex', 'Not documented')}")
+    if patient.get("mrn"):
+        lines.append(f"MRN: {patient['mrn']}")
+    lines.append("")
+    
+    # Allergies
+    lines.append("ALLERGIES")
+    if allergies:
+        for allergy in allergies:
+            substance = allergy.get("substance", "Unknown")
+            reaction = allergy.get("reaction", "")
+            conf = allergy.get("confidence", 0)
+            line = f"  • {substance}"
+            if reaction:
+                line += f" - {reaction}"
+            if conf < 0.7:
+                line += f" (confidence: {conf:.0%})"
+            lines.append(line)
+    else:
+        lines.append("  None documented")
+    lines.append("")
+    
+    # Subjective
+    lines.append("SUBJECTIVE")
+    lines.append("  Patient presented for clinical evaluation.")
+    if record.get("notes", {}).get("subjective"):
+        lines.append(f"  {record['notes']['subjective']}")
+    else:
+        lines.append("  Details from transcript: See source documentation")
+    lines.append("")
+    
+    # Objective
+    lines.append("OBJECTIVE")
+    
+    # Vitals
+    if vitals:
+        lines.append("  Vitals:")
+        for vital in vitals:
+            v_type = vital.get("type", "Unknown")
+            value = vital.get("value", "")
+            unit = vital.get("unit", "")
+            lines.append(f"    {v_type}: {value} {unit}".strip())
+    
+    # Labs
+    if labs:
+        lines.append("  Laboratory Results:")
+        for lab in labs:
+            test = lab.get("test", "Unknown")
+            value = lab.get("value", "")
+            unit = lab.get("unit", "")
+            ref_range = lab.get("reference_range", "")
+            line = f"    {test}: {value} {unit}".strip()
+            if ref_range:
+                line += f" (ref: {ref_range})"
+            lines.append(line)
+    
+    if not vitals and not labs:
+        lines.append("  No objective findings documented")
+    lines.append("")
+    
+    # Assessment
+    lines.append("ASSESSMENT")
+    if diagnoses:
+        for dx in diagnoses:
+            code = dx.get("code", "")
+            desc = dx.get("description", "")
+            conf = dx.get("confidence", 0)
+            line = f"  • "
+            if code:
+                line += f"[{code}] "
+            line += desc if desc else "Diagnosis documented"
+            if conf < 0.7:
+                line += f" (confidence: {conf:.0%})"
+            lines.append(line)
+    else:
+        lines.append("  No diagnoses documented")
+    lines.append("")
+    
+    # Plan
+    lines.append("PLAN")
+    
+    # Medications
+    if medications:
+        lines.append("  Medications:")
+        for med in medications:
+            name = med.get("name", "Unknown")
+            dose = med.get("dose", "")
+            route = med.get("route", "")
+            freq = med.get("frequency", "")
+            line = f"    • {name}"
+            if dose:
+                line += f" {dose}"
+            if route:
+                line += f" {route}"
+            if freq:
+                line += f" {freq}"
+            lines.append(line)
+    
+    # Procedures
+    if procedures:
+        lines.append("  Procedures:")
+        for proc in procedures:
+            name = proc.get("name", "Unknown")
+            date = proc.get("date", "")
+            line = f"    • {name}"
+            if date:
+                line += f" (scheduled: {date})"
+            lines.append(line)
+    
+    # Follow-up
+    if followups:
+        lines.append("  Follow-up:")
+        for fu in followups:
+            if isinstance(fu, dict):
+                desc = fu.get("description", str(fu))
+                timeframe = fu.get("timeframe", "")
+                line = f"    • {desc}"
+                if timeframe:
+                    line += f" ({timeframe})"
+                lines.append(line)
+            else:
+                lines.append(f"    • {fu}")
+    
+    if not medications and not procedures and not followups:
+        lines.append("  No treatment plan documented")
+    lines.append("")
+    
+    # Warnings
+    warnings = []
+    if validation.get("schema_errors"):
+        warnings.append(f"⚠ Validation Issues: {len(validation['schema_errors'])} errors detected")
+    if validation.get("missing_fields"):
+        warnings.append(f"⚠ Missing Required Fields: {', '.join(validation['missing_fields'][:3])}")
+    if validation.get("needs_review"):
+        warnings.append("⚠ This record requires clinical review")
+    if conflicts.get("conflicts"):
+        warnings.append(f"⚠ Conflicts Detected: {len(conflicts.get('conflicts', []))} unresolved")
+    
+    if warnings:
+        lines.append("--- SYSTEM WARNINGS ---")
+        lines.extend(warnings)
+        lines.append("")
+    
+    lines.append("=" * 60)
+    lines.append("Note generated from structured clinical record")
+    
+    return "\n".join(lines)
+
+
+def _build_history_context(state: GraphState) -> str:
+    """Build a patient history summary string for the LLM prompt."""
+    prf = state.get("patient_record_fields") or {}
+    if not prf.get("loaded_from_db"):
+        return ""
+
+    parts = []
+    visit_count = prf.get("visit_count", 0)
+    if visit_count > 0:
+        parts.append(f"This is visit #{visit_count + 1} for this patient.")
+
+    prior_facts = prf.get("prior_facts", {})
+    for fact_type, facts in prior_facts.items():
+        if facts:
+            keys = [f.get("fact_key", "?") for f in facts[:5]]
+            parts.append(f"Prior {fact_type}s: {', '.join(keys)}")
+
+    demographics = prf.get("demographics", {})
+    if demographics.get("full_name"):
+        parts.append(f"Patient: {demographics['full_name']}")
+
+    return "; ".join(parts) if parts else ""

--- a/server/app/agents/nodes/package.py
+++ b/server/app/agents/nodes/package.py
@@ -1,0 +1,195 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..state import GraphState
+from .export import write_report_pdf
+
+
+class _SafeEncoder(json.JSONEncoder):
+    """JSON encoder that handles non-serializable types gracefully."""
+    def default(self, o: Any) -> Any:
+        if isinstance(o, type):
+            return o.__name__
+        try:
+            return super().default(o)
+        except TypeError:
+            return str(o)
+
+
+LIST_MERGE_KEYS = {
+    "diagnoses": "code",
+    "medications": "name",
+    "allergies": "substance",
+    "problems": "name",
+    "labs": "test",
+    "procedures": "name",
+}
+
+
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    if isinstance(value, list) and not value:
+        return True
+    if isinstance(value, dict) and not value:
+        return True
+    return False
+
+
+def _merge_lists(primary: List[Dict[str, Any]], fallback: List[Dict[str, Any]], key: str) -> List[Dict[str, Any]]:
+    merged: List[Dict[str, Any]] = []
+    seen = set()
+
+    for item in primary:
+        merge_value = item.get(key)
+        if merge_value:
+            seen.add(merge_value)
+        merged.append(item)
+
+    for item in fallback:
+        merge_value = item.get(key)
+        if merge_value and merge_value in seen:
+            continue
+        merged.append(item)
+        if merge_value:
+            seen.add(merge_value)
+
+    return merged
+
+
+def _merge_records(primary: Dict[str, Any], fallback: Dict[str, Any]) -> Dict[str, Any]:
+    merged = dict(fallback)
+
+    for key, value in primary.items():
+        if isinstance(value, dict):
+            merged[key] = _merge_records(value, merged.get(key, {})) if isinstance(merged.get(key), dict) else value
+            continue
+        if isinstance(value, list):
+            fallback_list = merged.get(key, [])
+            if key in LIST_MERGE_KEYS and isinstance(fallback_list, list):
+                merged[key] = _merge_lists(value, fallback_list, LIST_MERGE_KEYS[key])
+            elif not _is_missing(value):
+                merged[key] = value
+            continue
+        if not _is_missing(value):
+            merged[key] = value
+
+    return merged
+
+
+def _build_report_text(state: GraphState, merged_record: Dict[str, Any]) -> str:
+    summary = state.get("session_summary")
+    summary_text = summary if isinstance(summary, str) else json.dumps(summary or {}, indent=2, sort_keys=True)
+    clinical_note = state.get("clinical_note") or ""
+
+    report_sections = [
+        "CLINICAL DOCUMENTATION REPORT",
+        f"Session ID: {state.get('session_id')}",
+        f"Patient ID: {state.get('patient_id')}",
+        f"Doctor ID: {state.get('doctor_id')}",
+        "",
+        "SESSION SUMMARY",
+        summary_text,
+        "",
+        "CLINICAL NOTE",
+        clinical_note,
+        "",
+        "STRUCTURED RECORD",
+        json.dumps(merged_record, indent=2, sort_keys=True, cls=_SafeEncoder),
+        "",
+        "VALIDATION REPORT",
+        json.dumps(state.get("validation_report") or {}, indent=2, sort_keys=True, cls=_SafeEncoder),
+        "",
+        "CONFLICT REPORT",
+        json.dumps(state.get("conflict_report") or {}, indent=2, sort_keys=True, cls=_SafeEncoder),
+    ]
+
+    return "\n".join(report_sections)
+
+
+def _load_template(template_name: str) -> str:
+    template_path = Path(__file__).with_name(template_name)
+    return template_path.read_text(encoding="utf-8")
+
+
+def _render_html(template: str, context: Dict[str, Any]) -> str:
+    rendered = template
+    for key, value in context.items():
+        rendered = rendered.replace(f"{{{{{key}}}}}", value)
+    return rendered
+
+
+def package_outputs_node(state: GraphState) -> GraphState:
+    """Package final artifacts for export and storage."""
+    state = state.copy()
+    structured = state.get("structured_record") or {}
+    prior_profile = state.get("patient_record_fields") or state.get("inputs", {}).get("patient_profile", {})
+    merged_record = _merge_records(structured, prior_profile)
+
+    report_text = _build_report_text(state, merged_record)
+    summary = state.get("session_summary")
+    summary_text = summary if isinstance(summary, str) else json.dumps(summary or {}, indent=2, sort_keys=True)
+    html_template = _load_template("report_template.html")
+    css_styles = _load_template("report_styles.css")
+    html_report = _render_html(
+        html_template,
+        {
+            "title": "Clinical Documentation Report",
+            "styles": css_styles,
+            "session_id": str(state.get("session_id", "")),
+            "patient_id": str(state.get("patient_id", "")),
+            "doctor_id": str(state.get("doctor_id", "")),
+            "session_summary": summary_text,
+            "clinical_note": state.get("clinical_note") or "",
+            "structured_record": json.dumps(merged_record, indent=2, sort_keys=True, cls=_SafeEncoder),
+            "validation_report": json.dumps(state.get("validation_report") or {}, indent=2, sort_keys=True, cls=_SafeEncoder),
+            "conflict_report": json.dumps(state.get("conflict_report") or {}, indent=2, sort_keys=True, cls=_SafeEncoder),
+        },
+    )
+
+    repo_root = Path(__file__).resolve().parents[3]
+    output_dir = repo_root / "storage" / "outputs"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    session_id = state.get("session_id", "session")
+    report_path = output_dir / f"{session_id}_report.txt"
+    html_path = output_dir / f"{session_id}_report.html"
+    pdf_path = output_dir / f"{session_id}_report.pdf"
+
+    # Write text report
+    report_path.write_text(report_text, encoding="utf-8")
+    html_path.write_text(html_report, encoding="utf-8")
+    try:
+        write_report_pdf(
+            output_path=pdf_path,
+            title="Clinical Documentation Report",
+            meta=[
+                ("Session ID", str(state.get("session_id", ""))),
+                ("Patient ID", str(state.get("patient_id", ""))),
+                ("Doctor ID", str(state.get("doctor_id", ""))),
+            ],
+            summary_text=summary_text,
+            clinical_note=state.get("clinical_note") or "",
+            structured_record=merged_record,
+            validation_report=state.get("validation_report") or {},
+            conflict_report=state.get("conflict_report") or {},
+        )
+    except RuntimeError:
+        # reportlab not installed — skip PDF, continue with text + HTML
+        pdf_path = None
+
+    state.setdefault("controls", {"attempts": {}, "budget": {}, "trace_log": []})
+    state["controls"]["trace_log"].append(
+        {
+            "node": "package_outputs",
+            "report_path": str(report_path),
+            "html_path": str(html_path),
+            "pdf_path": str(pdf_path),
+        }
+    )
+    state["message"] = f"Packaged outputs: {report_path.name}, {html_path.name}" + (f", {pdf_path.name}" if pdf_path else "")
+    state["structured_record"] = merged_record
+    return state

--- a/server/app/agents/nodes/persist_results.py
+++ b/server/app/agents/nodes/persist_results.py
@@ -1,0 +1,357 @@
+"""
+Persist Results Node — Writes pipeline outputs to the database.
+
+Runs as the final node before END to:
+  1. Create / update a MedicalRecord with the structured record + SOAP note
+  2. Store clinical fact embeddings (with Layer 3 confidence gating)
+  3. Update Session status to COMPLETED
+  4. Create an AuditLog entry for the pipeline run
+
+If no DB services are available, the node is a no-op (pipeline still
+produces file-based outputs via package_outputs_node).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from ..config import AgentContext
+from ..state import GraphState
+
+logger = logging.getLogger(__name__)
+
+
+def persist_results_node(state: GraphState, ctx: AgentContext) -> GraphState:
+    """
+    Persist pipeline results to the database.
+
+    Operations (all best-effort — partial failures don't block the pipeline):
+      1. Upsert MedicalRecord  (record_repo)
+      2. Store clinical fact embeddings  (embedding_service)
+      3. Mark Session as completed  (session_repo)
+      4. Write AuditLog entry  (db_session_factory)
+    """
+    state = {**state}
+    controls = state.get("controls", {"attempts": {}, "budget": {}, "trace_log": []})
+    patient_id = state.get("patient_id", "")
+    session_id = state.get("session_id", "")
+    doctor_id = state.get("doctor_id", "")
+
+    persisted: Dict[str, bool] = {
+        "medical_record": False,
+        "clinical_embeddings": False,
+        "session_status": False,
+        "audit_log": False,
+    }
+
+    # ── 1. Create / update MedicalRecord ────────────────────────────────────
+    record_id = _persist_medical_record(
+        ctx, state, patient_id, session_id, doctor_id, persisted
+    )
+
+    # ── 2. Store clinical fact embeddings ───────────────────────────────────
+    _persist_clinical_embeddings(
+        ctx, state, patient_id, session_id, record_id, persisted
+    )
+
+    # ── 3. Update session status ────────────────────────────────────────────
+    _update_session_status(ctx, session_id, persisted)
+
+    # ── 4. Audit log ────────────────────────────────────────────────────────
+    _write_audit_log(ctx, patient_id, session_id, doctor_id, record_id, persisted)
+
+    # ── Commit all changes ──────────────────────────────────────────────────
+    if ctx.db_session_factory is not None:
+        try:
+            # The repos share the same session — commit once
+            if ctx.record_repo and ctx.record_repo.db:
+                ctx.record_repo.db.commit()
+                logger.info("[PersistResults] Committed all DB changes")
+        except Exception as e:
+            logger.error(f"[PersistResults] Commit failed: {e}")
+            if ctx.record_repo and ctx.record_repo.db:
+                ctx.record_repo.db.rollback()
+
+    # ── 5. Trigger post-processing (best-effort, non-blocking) ──────────
+    _trigger_post_processing(state, patient_id, session_id, doctor_id)
+
+    # Trace
+    controls.setdefault("trace_log", []).append({
+        "node": "persist_results",
+        "action": "persisted",
+        "detail": persisted,
+        "record_id": record_id,
+        "timestamp": datetime.now().isoformat(),
+    })
+    state["controls"] = controls
+
+    summary = ", ".join(f"{k}={'OK' if v else 'SKIP'}" for k, v in persisted.items())
+    state["message"] = (state.get("message") or "") + f" | DB persist: {summary}"
+    logger.info(f"[PersistResults] {summary}")
+
+    return state
+
+
+# ─── Internal helpers ───────────────────────────────────────────────────────
+
+def _persist_medical_record(
+    ctx: AgentContext,
+    state: GraphState,
+    patient_id: str,
+    session_id: str,
+    doctor_id: str,
+    persisted: Dict[str, bool],
+) -> Optional[str]:
+    """Create or update MedicalRecord with automatic version incrementing."""
+    if ctx.record_repo is None:
+        return None
+
+    record_id = str(uuid.uuid4())
+
+    try:
+        from app.database.models import MedicalRecord
+
+        structured_data = state.get("structured_record", {})
+        clinical_suggestions = state.get("clinical_suggestions")
+        soap_note = state.get("clinical_note")
+        validation_report = state.get("validation_report")
+        conflict_report = state.get("conflict_report")
+
+        # Compute overall confidence from validation
+        confidence_score = None
+        if validation_report:
+            errors = len(validation_report.get("schema_errors", []))
+            missing = len(validation_report.get("missing_fields", []))
+            conflicts = len(validation_report.get("conflicts", []))
+            # Simple heuristic: 100 - (10 * errors) - (5 * missing) - (15 * conflicts)
+            confidence_score = max(0, 100 - (10 * errors) - (5 * missing) - (15 * conflicts))
+
+        # Determine if record should be finalized
+        needs_review = (validation_report or {}).get("needs_review", False)
+        is_final = not needs_review and (confidence_score or 0) >= 80
+
+        # ── Version incrementing: check for existing records for this session ──
+        version = 1
+        try:
+            db = ctx.record_repo.db
+            if db is not None:
+                existing = (
+                    db.query(MedicalRecord)
+                    .filter(MedicalRecord.session_id == session_id)
+                    .order_by(MedicalRecord.version.desc())
+                    .first()
+                )
+                if existing:
+                    version = (existing.version or 0) + 1
+                    logger.info(
+                        f"[PersistResults] Found existing record v{existing.version} "
+                        f"for session {session_id}, creating v{version}"
+                    )
+        except Exception as ve:
+            logger.debug(f"[PersistResults] Version check skipped: {ve}")
+
+        record = MedicalRecord(
+            id=record_id,
+            patient_id=patient_id,
+            session_id=session_id,
+            structured_data=structured_data,
+            clinical_suggestions=clinical_suggestions,
+            soap_note=soap_note,
+            validation_report=validation_report,
+            conflict_report=conflict_report,
+            confidence_score=confidence_score,
+            version=version,
+            is_final=is_final,
+            record_type="SOAP",
+            created_by=doctor_id,
+        )
+
+        ctx.record_repo.create(record)
+        persisted["medical_record"] = True
+        logger.info(
+            f"[PersistResults] Created MedicalRecord {record_id} "
+            f"(v{version}, confidence={confidence_score}, is_final={is_final})"
+        )
+        return record_id
+
+    except Exception as e:
+        logger.error(f"[PersistResults] Failed to create MedicalRecord: {e}")
+        return None
+
+
+def _persist_clinical_embeddings(
+    ctx: AgentContext,
+    state: GraphState,
+    patient_id: str,
+    session_id: str,
+    record_id: Optional[str],
+    persisted: Dict[str, bool],
+) -> None:
+    """Store each candidate fact as a clinical embedding (Layer 3 gating applied)."""
+    if ctx.embedding_service is None or not patient_id:
+        return
+
+    candidates = state.get("candidate_facts", [])
+    evidence_map = state.get("evidence_map", {})
+
+    stored_count = 0
+    skipped_count = 0
+
+    try:
+        for fact in candidates:
+            fact_id = fact.get("fact_id", "")
+            confidence = fact.get("confidence", 0.5)
+
+            # Get the best evidence snippet as source_span
+            evidence_items = evidence_map.get(fact_id, [])
+            source_span = None
+            grounding_score = None
+
+            if evidence_items:
+                best_evidence = max(evidence_items, key=lambda e: e.get("confidence", 0))
+                source_span = best_evidence.get("snippet", "")
+
+                # Layer 1: Verify grounding
+                if source_span:
+                    try:
+                        grounding_score, is_grounded = ctx.embedding_service.verify_grounding(
+                            source_span=source_span,
+                            extracted_text=ctx.embedding_service._fact_to_text(fact),
+                        )
+                        if not is_grounded:
+                            logger.warning(
+                                f"[PersistResults] Fact {fact_id} failed grounding "
+                                f"(score={grounding_score:.3f} < {ctx.grounding_threshold})"
+                            )
+                            # Still store, but mark is_final=False
+                    except Exception:
+                        pass
+
+            # Layer 3: Confidence gating applied inside store_clinical_embedding
+            is_final = confidence >= ctx.persistence_floor
+            if grounding_score is not None and grounding_score < ctx.grounding_threshold:
+                is_final = False
+
+            ctx.embedding_service.store_clinical_embedding(
+                patient_id=patient_id,
+                session_id=session_id,
+                fact=fact,
+                record_id=record_id,
+                source_span=source_span,
+                grounding_score=grounding_score,
+                is_final=is_final,
+            )
+            stored_count += 1
+
+        persisted["clinical_embeddings"] = stored_count > 0
+        logger.info(
+            f"[PersistResults] Stored {stored_count} clinical embeddings, "
+            f"skipped {skipped_count}"
+        )
+
+    except Exception as e:
+        logger.error(f"[PersistResults] Failed to store clinical embeddings: {e}")
+
+
+def _update_session_status(
+    ctx: AgentContext,
+    session_id: str,
+    persisted: Dict[str, bool],
+) -> None:
+    """Mark session as completed."""
+    if ctx.session_repo is None or not session_id:
+        return
+
+    try:
+        ctx.session_repo.end_session(session_id)
+        persisted["session_status"] = True
+        logger.info(f"[PersistResults] Session {session_id} marked as completed")
+    except Exception as e:
+        logger.error(f"[PersistResults] Failed to update session status: {e}")
+
+
+def _write_audit_log(
+    ctx: AgentContext,
+    patient_id: str,
+    session_id: str,
+    doctor_id: str,
+    record_id: Optional[str],
+    persisted: Dict[str, bool],
+) -> None:
+    """Write HIPAA audit trail entry."""
+    if ctx.db_session_factory is None:
+        return
+
+    try:
+        from app.database.models import AuditLog
+
+        # Use the same session as the repos
+        db = None
+        if ctx.record_repo and ctx.record_repo.db:
+            db = ctx.record_repo.db
+        else:
+            return
+
+        audit = AuditLog(
+            user_id=doctor_id,
+            user_role="doctor",
+            action="pipeline_complete",
+            resource_type="medical_record",
+            resource_id=record_id or session_id,
+            details={
+                "session_id": session_id,
+                "patient_id": patient_id,
+                "record_id": record_id,
+                "persisted": persisted,
+            },
+            success=True,
+        )
+        db.add(audit)
+        db.flush()
+        persisted["audit_log"] = True
+
+    except Exception as e:
+        logger.error(f"[PersistResults] Failed to write audit log: {e}")
+
+
+def _trigger_post_processing(
+    state: GraphState,
+    patient_id: str,
+    session_id: str,
+    doctor_id: str,
+) -> None:
+    """
+    Fire-and-forget post-session analysis.
+
+    This runs synchronously for now; a production deployment would push
+    this to a background task queue (Celery / ARQ / etc.).
+    """
+    try:
+        from app.core.post_processor import get_post_processor
+        import asyncio
+
+        final_record = state.get("structured_record", {})
+        if not final_record:
+            return
+
+        processor = get_post_processor()
+
+        # If there's a running event loop, schedule; otherwise run_sync.
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(
+                processor.run(session_id, final_record, patient_id, doctor_id)
+            )
+        except RuntimeError:
+            asyncio.run(
+                processor.run(session_id, final_record, patient_id, doctor_id)
+            )
+
+        logger.info("[PersistResults] Post-processing triggered for session %s", session_id)
+
+    except Exception as e:
+        # Post-processing failure must never break the pipeline
+        logger.warning("[PersistResults] Post-processing trigger failed: %s", e)


### PR DESCRIPTION
…packaging, persistence

- generate_note: LLM prompt constructs fully structured SOAP note from filled StructuredRecord and patient context; embeds clinical alert summaries as inline annotations with source evidence references
- package_outputs: assembles final pipeline artefacts (SOAP note, structured record, audit trail, clinical alerts) into RunResult dict for API response
- persist_results: writes StructuredRecord and SOAP note to PostgreSQL; upserts patient profile; stores embedding vectors to pgvector; appends immutable audit log entry; respects human_review_gate approval state
- export: formats RunResult for downstream export (PDF/HTML/JSON) by delegating to ExportService with template selection