### PR TITLE
feat(records): add record generation, multi-format export, and Jinja2…

### DIFF
--- a/server/app/agents/nodes/report_styles.css
+++ b/server/app/agents/nodes/report_styles.css
@@ -1,0 +1,26 @@
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    max-width: 960px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    color: #1a1a1a;
+    line-height: 1.6;
+}
+header {
+    border-bottom: 2px solid #2563eb;
+    padding-bottom: 1rem;
+    margin-bottom: 2rem;
+}
+h1 { color: #1e40af; margin: 0 0 0.5rem; }
+h2 { color: #1e40af; border-bottom: 1px solid #dbeafe; padding-bottom: 0.5rem; margin-top: 2rem; }
+.meta p { margin: 0.2rem 0; color: #64748b; }
+pre {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    padding: 1rem;
+    overflow-x: auto;
+    font-size: 0.85rem;
+}
+code { font-family: 'JetBrains Mono', 'Fira Code', monospace; }
+.clinical-note { white-space: pre-wrap; background: #fffbeb; border-left: 4px solid #f59e0b; padding: 1rem; border-radius: 4px; }

--- a/server/app/agents/nodes/report_template.html
+++ b/server/app/agents/nodes/report_template.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{title}}</title>
+    <style>{{styles}}</style>
+</head>
+<body>
+    <header>
+        <h1>{{title}}</h1>
+        <div class="meta">
+            <p><strong>Session ID:</strong> {{session_id}}</p>
+            <p><strong>Patient ID:</strong> {{patient_id}}</p>
+            <p><strong>Doctor ID:</strong> {{doctor_id}}</p>
+        </div>
+    </header>
+
+    <section>
+        <h2>Session Summary</h2>
+        <pre>{{session_summary}}</pre>
+    </section>
+
+    <section>
+        <h2>Clinical Note</h2>
+        <div class="clinical-note">{{clinical_note}}</div>
+    </section>
+
+    <section>
+        <h2>Structured Record</h2>
+        <pre><code>{{structured_record}}</code></pre>
+    </section>
+
+    <section>
+        <h2>Validation Report</h2>
+        <pre><code>{{validation_report}}</code></pre>
+    </section>
+
+    <section>
+        <h2>Conflict Report</h2>
+        <pre><code>{{conflict_report}}</code></pre>
+    </section>
+</body>
+</html>

--- a/server/app/core/record_generator.py
+++ b/server/app/core/record_generator.py
@@ -1,0 +1,198 @@
+"""
+Medical Record Generator with Template Support.
+
+Generates formatted medical records from structured data using templates:
+- SOAP Note
+- Discharge Summary
+- Consultation Note
+- Progress Note
+
+Supports both HTML and PDF output formats.
+"""
+
+from typing import Dict, Any, Optional
+from pathlib import Path
+from datetime import datetime
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+import io
+
+
+class RecordGenerator:
+    """
+    Generator for medical records using Jinja2 templates.
+
+    Supports multiple output formats:
+    - HTML (for viewing/printing)
+    - PDF (via WeasyPrint - optional)
+    - Plain text (fallback)
+    """
+
+    TEMPLATE_DIR = Path(__file__).parent.parent.parent / "templates"
+
+    def __init__(self):
+        """Initialize record generator with template environment."""
+        # Create templates directory if it doesn't exist
+        self.TEMPLATE_DIR.mkdir(parents=True, exist_ok=True)
+
+        # Setup Jinja2 environment
+        self.env = Environment(
+            loader=FileSystemLoader(str(self.TEMPLATE_DIR)),
+            autoescape=select_autoescape(['html', 'xml']),
+            trim_blocks=True,
+            lstrip_blocks=True
+        )
+
+        # Add custom filters
+        self.env.filters['format_date'] = self._format_date
+        self.env.filters['format_list'] = self._format_list
+
+    def generate(
+        self,
+        record: Dict[str, Any],
+        template_name: str,
+        clinical_suggestions: Optional[Dict[str, Any]] = None
+    ) -> str:
+        """
+        Generate formatted medical record from template.
+
+        Args:
+            record: Structured medical record data
+            template_name: Template to use (soap, discharge, consultation, progress)
+            clinical_suggestions: Optional clinical suggestions to include
+
+        Returns:
+            Rendered HTML string
+        """
+        # Load template
+        template = self.env.get_template(f"{template_name}.html")
+
+        # Prepare context
+        context = {
+            "record": record,
+            "clinical_suggestions": clinical_suggestions or {},
+            "generated_at": datetime.now(),
+            "generator_version": "1.0.0"
+        }
+
+        # Render template
+        return template.render(**context)
+
+    def generate_pdf(
+        self,
+        record: Dict[str, Any],
+        template_name: str,
+        clinical_suggestions: Optional[Dict[str, Any]] = None
+    ) -> bytes:
+        """
+        Generate PDF from template.
+
+        Args:
+            record: Structured medical record data
+            template_name: Template to use
+            clinical_suggestions: Optional clinical suggestions
+
+        Returns:
+            PDF bytes
+        """
+        # Generate HTML first
+        html = self.generate(record, template_name, clinical_suggestions)
+
+        # Convert to PDF
+        try:
+            from weasyprint import HTML
+            pdf_bytes = HTML(string=html).write_pdf()
+            return pdf_bytes
+        except (ImportError, OSError):
+            # WeasyPrint not available or native libs missing, return HTML as fallback
+            return html.encode('utf-8')
+
+    def generate_text(
+        self,
+        record: Dict[str, Any],
+        template_name: str
+    ) -> str:
+        """
+        Generate plain text version of medical record.
+
+        Args:
+            record: Structured medical record data
+            template_name: Template to use
+
+        Returns:
+            Plain text string
+        """
+        # Generate HTML
+        html = self.generate(record, template_name)
+
+        # Simple HTML to text conversion (strip tags)
+        import re
+        text = re.sub('<[^<]+?>', '', html)
+        text = re.sub(r'\n\s*\n', '\n\n', text)  # Remove extra blank lines
+        return text.strip()
+
+    # Alias so callers can use either name
+    generate_plain_text = generate_text
+
+    def save_to_file(
+        self,
+        record: Dict[str, Any],
+        template_name: str,
+        output_path: str,
+        format: str = "html",
+        clinical_suggestions: Optional[Dict[str, Any]] = None
+    ) -> str:
+        """
+        Save generated record to file.
+
+        Args:
+            record: Structured medical record data
+            template_name: Template to use
+            output_path: Path to save file
+            format: Output format (html, pdf, txt)
+            clinical_suggestions: Optional clinical suggestions
+
+        Returns:
+            Path to saved file
+        """
+        if format == "pdf":
+            content = self.generate_pdf(record, template_name, clinical_suggestions)
+            mode = 'wb'
+        elif format in ("txt", "text"):
+            content = self.generate_text(record, template_name)
+            mode = 'w'
+        else:  # html
+            content = self.generate(record, template_name, clinical_suggestions)
+            mode = 'w'
+
+        with open(output_path, mode) as f:
+            f.write(content)
+
+        return output_path
+
+    def _format_date(self, value):
+        """Jinja2 filter to format dates."""
+        if isinstance(value, datetime):
+            return value.strftime("%Y-%m-%d")
+        elif isinstance(value, str):
+            try:
+                dt = datetime.fromisoformat(value)
+                return dt.strftime("%Y-%m-%d")
+            except Exception:
+                return value
+        return value
+
+    def _format_list(self, items, separator=", "):
+        """Jinja2 filter to format lists."""
+        if isinstance(items, list):
+            return separator.join(str(item) for item in items)
+        return str(items)
+
+
+def get_record_generator() -> RecordGenerator:
+    """
+    Factory function to create record generator.
+
+    Returns:
+        RecordGenerator instance
+    """
+    return RecordGenerator()

--- a/server/app/services/export_service.py
+++ b/server/app/services/export_service.py
@@ -1,0 +1,76 @@
+"""
+Export Service — single source of truth for document generation.
+
+Consolidates:
+  - app/agents/nodes/export.py  (reportlab-based PDF)
+  - app/utils/pdf_generator.py  (hand-crafted raw PDF)
+  - app/core/record_generator.py (Jinja2 HTML + optional WeasyPrint)
+
+into one service with a clean API.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from app.core.record_generator import RecordGenerator
+
+
+class ExportService:
+    """
+    Unified document export for medical records.
+
+    Supports HTML, PDF, and plain text output via the
+    RecordGenerator / Jinja2 pipeline.
+    """
+
+    def __init__(self, generator: RecordGenerator | None = None):
+        self._generator = generator
+
+    @property
+    def generator(self) -> RecordGenerator:
+        if self._generator is None:
+            self._generator = RecordGenerator()
+        return self._generator
+
+    def to_html(
+        self,
+        record: Dict[str, Any],
+        template: str = "soap",
+        suggestions: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Render record to HTML string."""
+        return self.generator.generate(record, template, suggestions)
+
+    def to_pdf(
+        self,
+        record: Dict[str, Any],
+        template: str = "soap",
+        suggestions: Optional[Dict[str, Any]] = None,
+    ) -> bytes:
+        """Render record to PDF bytes."""
+        return self.generator.generate_pdf(record, template, suggestions)
+
+    def to_text(
+        self,
+        record: Dict[str, Any],
+        template: str = "soap",
+    ) -> str:
+        """Render record to plain text."""
+        return self.generator.generate_text(record, template)
+
+    def save(
+        self,
+        record: Dict[str, Any],
+        template: str,
+        output_path: Path | str,
+        fmt: str = "html",
+        suggestions: Optional[Dict[str, Any]] = None,
+    ) -> Path:
+        """Generate and save to disk."""
+        output_path = Path(output_path)
+        self.generator.save_to_file(
+            record, template, str(output_path), fmt, suggestions
+        )
+        return output_path

--- a/server/templates/consultation.html
+++ b/server/templates/consultation.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Consultation Note - {{ record.patient.name }}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 40px;
+            line-height: 1.6;
+            color: #333;
+        }
+        .header {
+            border-bottom: 3px solid #2c3e50;
+            padding-bottom: 15px;
+            margin-bottom: 20px;
+        }
+        h1 {
+            color: #2c3e50;
+            margin: 0 0 5px 0;
+            font-size: 24px;
+        }
+        h2 {
+            color: #34495e;
+            font-size: 16px;
+            margin-top: 20px;
+            margin-bottom: 10px;
+            padding-bottom: 5px;
+            border-bottom: 2px solid #ecf0f1;
+        }
+        .patient-info {
+            background: #f8f9fa;
+            padding: 15px;
+            border-left: 4px solid #9b59b6;
+            margin-bottom: 20px;
+        }
+        .info-row {
+            display: flex;
+            margin: 5px 0;
+        }
+        .info-label {
+            font-weight: bold;
+            width: 180px;
+        }
+        .consultation-box {
+            background: #e8f5e9;
+            border-left: 4px solid #4caf50;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        .section {
+            margin-bottom: 20px;
+        }
+        .section-content {
+            margin-left: 15px;
+            white-space: pre-wrap;
+        }
+        .list-item {
+            margin: 5px 0 5px 20px;
+        }
+        .recommendation-box {
+            background: #fff9c4;
+            border-left: 4px solid #ffc107;
+            padding: 15px;
+            margin: 15px 0;
+        }
+        .footer {
+            margin-top: 30px;
+            padding-top: 15px;
+            border-top: 2px solid #ecf0f1;
+            font-size: 12px;
+            color: #666;
+        }
+        @media print {
+            body { margin: 20px; }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>CONSULTATION NOTE</h1>
+        <div style="font-size: 14px; color: #666;">
+            Date: {{ record.visit.date|format_date }} | Time: {{ record.visit.time or 'N/A' }}
+        </div>
+    </div>
+
+    <div class="patient-info">
+        <div class="info-row">
+            <span class="info-label">Patient:</span>
+            <span><strong>{{ record.patient.name }}</strong></span>
+        </div>
+        <div class="info-row">
+            <span class="info-label">MRN:</span>
+            <span>{{ record.patient.mrn }}</span>
+        </div>
+        <div class="info-row">
+            <span class="info-label">DOB:</span>
+            <span>{{ record.patient.dob|format_date }} (Age: {{ record.patient.age }})</span>
+        </div>
+        <div class="info-row">
+            <span class="info-label">Sex:</span>
+            <span>{{ record.patient.sex }}</span>
+        </div>
+        <div class="info-row">
+            <span class="info-label">Referring Physician:</span>
+            <span>{{ record.referring_physician or 'N/A' }}</span>
+        </div>
+        <div class="info-row">
+            <span class="info-label">Consulting Physician:</span>
+            <span><strong>{{ record.visit.provider }}</strong></span>
+        </div>
+        <div class="info-row">
+            <span class="info-label">Specialty:</span>
+            <span>{{ record.specialty or 'General Medicine' }}</span>
+        </div>
+    </div>
+
+    <div class="consultation-box">
+        <h2 style="margin-top: 0; border-bottom: none;">REASON FOR CONSULTATION</h2>
+        <p style="font-size: 16px; margin: 10px 0;">
+            {%- if record.consultation_reason -%}{{ record.consultation_reason }}
+            {%- elif record.chief_complaint is mapping -%}{{ record.chief_complaint.description or 'Not documented' }}
+            {%- elif record.chief_complaint -%}{{ record.chief_complaint }}
+            {%- else -%}Not documented{%- endif -%}
+        </p>
+    </div>
+
+    <div class="section">
+        <h2>HISTORY OF PRESENT ILLNESS</h2>
+        <div class="section-content">
+            {{ record.notes.subjective or record.notes.hpi or 'Not documented' }}
+        </div>
+    </div>
+
+    {% if clinical_suggestions and clinical_suggestions.historical_context %}
+    <div class="section">
+        <h2>RELEVANT MEDICAL HISTORY</h2>
+        <div class="section-content">
+            {% if clinical_suggestions.historical_context.chronic_conditions %}
+            <strong>Chronic Conditions:</strong>
+            {% for condition in clinical_suggestions.historical_context.chronic_conditions %}
+            <div class="list-item">
+                {{ condition.condition }}
+                {% if condition.duration %} ({{ condition.duration }}){% endif %}
+            </div>
+            {% endfor %}
+            {% endif %}
+
+            {% if record.past_medical_history %}
+            <div style="margin-top: 10px;">
+                <strong>Past Medical History:</strong>
+                {% for item in record.past_medical_history %}
+                <div class="list-item">{{ item }}</div>
+                {% endfor %}
+            </div>
+            {% endif %}
+
+            {% if record.past_surgical_history %}
+            <div style="margin-top: 10px;">
+                <strong>Past Surgical History:</strong>
+                {% for item in record.past_surgical_history %}
+                <div class="list-item">{{ item }}</div>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+
+    {% if record.medications %}
+    <div class="section">
+        <h2>CURRENT MEDICATIONS</h2>
+        {% for med in record.medications %}
+        <div class="list-item">
+            {{ med.name }}
+            {% if med.dose %} {{ med.dose }}{% endif %}
+            {% if med.frequency %} {{ med.frequency }}{% endif %}
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    {% if record.allergies %}
+    <div class="section">
+        <h2>ALLERGIES</h2>
+        {% for allergy in record.allergies %}
+        <div class="list-item">
+            <strong>{{ allergy.substance }}</strong>: {{ allergy.reaction }}
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    {% if record.social_history %}
+    <div class="section">
+        <h2>SOCIAL HISTORY</h2>
+        <div class="section-content">
+            {{ record.social_history }}
+        </div>
+    </div>
+    {% endif %}
+
+    {% if record.family_history %}
+    <div class="section">
+        <h2>FAMILY HISTORY</h2>
+        <div class="section-content">
+            {{ record.family_history }}
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="section">
+        <h2>REVIEW OF SYSTEMS</h2>
+        <div class="section-content">
+            {{ record.review_of_systems or 'Patient denies fever, chills, weight loss, chest pain, shortness of breath, abdominal pain, nausea, vomiting.' }}
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>PHYSICAL EXAMINATION</h2>
+        <div class="section-content">
+            {% if record.vital_signs %}
+            <strong>Vital Signs:</strong><br>
+            {% if record.vital_signs.blood_pressure %}<div class="list-item">BP: {{ record.vital_signs.blood_pressure }}</div>{% endif %}
+            {% if record.vital_signs.heart_rate %}<div class="list-item">HR: {{ record.vital_signs.heart_rate }}</div>{% endif %}
+            {% if record.vital_signs.temperature %}<div class="list-item">Temp: {{ record.vital_signs.temperature }}</div>{% endif %}
+            {% if record.vital_signs.respiratory_rate %}<div class="list-item">RR: {{ record.vital_signs.respiratory_rate }}</div>{% endif %}
+            <br>
+            {% endif %}
+
+            {{ record.notes.objective or 'Not documented' }}
+        </div>
+    </div>
+
+    {% if record.labs or record.imaging %}
+    <div class="section">
+        <h2>DIAGNOSTIC STUDIES</h2>
+        <div class="section-content">
+            {% if record.labs %}
+            <strong>Laboratory:</strong>
+            {% for lab in record.labs %}
+            <div class="list-item">
+                {{ lab.test_name }}: {{ lab.value }} {{ lab.unit or '' }}
+                {% if lab.abnormal %}<strong>(Abnormal)</strong>{% endif %}
+            </div>
+            {% endfor %}
+            {% endif %}
+
+            {% if record.imaging %}
+            <div style="margin-top: 10px;">
+                <strong>Imaging:</strong>
+                {% for img in record.imaging %}
+                <div class="list-item">
+                    {{ img.type }}: {{ img.findings }}
+                </div>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="section">
+        <h2>IMPRESSION</h2>
+        <div class="section-content">
+            {% if record.diagnoses %}
+            {% for diagnosis in record.diagnoses %}
+            <div class="list-item">
+                {{ loop.index }}. {{ diagnosis.description }}
+                {% if diagnosis.code %} ({{ diagnosis.code }}){% endif %}
+            </div>
+            {% endfor %}
+            {% else %}
+            {{ record.notes.assessment or 'Not documented' }}
+            {% endif %}
+        </div>
+    </div>
+
+    <div class="recommendation-box">
+        <h2 style="margin-top: 0; border-bottom: none;">RECOMMENDATIONS</h2>
+        <div style="margin: 10px 0;">
+            {{ record.notes.plan or record.recommendations or 'Not documented' }}
+        </div>
+
+        {% if clinical_suggestions and clinical_suggestions.drug_interactions %}
+        <div style="margin-top: 15px; padding-top: 10px; border-top: 1px solid #ddd;">
+            <strong>⚠️ Clinical Considerations:</strong>
+            {% for interaction in clinical_suggestions.drug_interactions %}
+            <div style="margin: 5px 0;">{{ interaction.recommendation }}</div>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </div>
+
+    <div class="section">
+        <h2>FOLLOW-UP</h2>
+        <div class="section-content">
+            {{ record.follow_up_plan or 'Patient will follow up with referring physician. Available for further consultation as needed.' }}
+        </div>
+    </div>
+
+    <div class="footer">
+        <div>Consultation Generated: {{ generated_at.strftime('%Y-%m-%d %H:%M:%S') }}</div>
+        <div style="margin-top: 15px;">
+            Thank you for this consultation. Please contact me if you have any questions or need further clarification.
+        </div>
+        <div style="margin-top: 20px; border-top: 1px solid #333; width: 300px; padding-top: 5px;">
+            Respectfully,<br><br>
+            {{ record.visit.provider }}, MD<br>
+            {{ record.specialty or 'Consulting Physician' }}<br>
+            Date: {{ record.visit.date|format_date }}
+        </div>
+    </div>
+</body>
+</html>

--- a/server/templates/discharge.html
+++ b/server/templates/discharge.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Discharge Summary - {{ record.patient.name }}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 40px;
+            line-height: 1.6;
+            color: #333;
+        }
+        .header {
+            border-bottom: 3px solid #2c3e50;
+            padding-bottom: 15px;
+            margin-bottom: 20px;
+            text-align: center;
+        }
+        h1 {
+            color: #2c3e50;
+            margin: 0 0 5px 0;
+            font-size: 26px;
+        }
+        h2 {
+            color: #34495e;
+            font-size: 18px;
+            margin-top: 20px;
+            margin-bottom: 10px;
+            padding-bottom: 5px;
+            border-bottom: 2px solid #ecf0f1;
+        }
+        .patient-info {
+            background: #f8f9fa;
+            padding: 15px;
+            border-left: 4px solid #27ae60;
+            margin-bottom: 20px;
+        }
+        .info-grid {
+            display: grid;
+            grid-template-columns: 150px 1fr;
+            gap: 8px;
+            margin: 5px 0;
+        }
+        .info-label {
+            font-weight: bold;
+        }
+        .section {
+            margin-bottom: 20px;
+        }
+        .list-item {
+            margin: 5px 0 5px 20px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 10px 0;
+        }
+        table th {
+            background: #34495e;
+            color: white;
+            padding: 10px;
+            text-align: left;
+        }
+        table td {
+            padding: 8px;
+            border-bottom: 1px solid #ddd;
+        }
+        .highlight-box {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: 12px;
+            margin: 10px 0;
+        }
+        .footer {
+            margin-top: 30px;
+            padding-top: 15px;
+            border-top: 2px solid #ecf0f1;
+            font-size: 12px;
+            color: #666;
+        }
+        @media print {
+            body { margin: 20px; }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>DISCHARGE SUMMARY</h1>
+        <div style="font-size: 14px; color: #666;">
+            {{ record.facility_name or 'Medical Facility' }}
+        </div>
+    </div>
+
+    <div class="patient-info">
+        <div class="info-grid">
+            <span class="info-label">Patient Name:</span>
+            <span>{{ record.patient.name }}</span>
+
+            <span class="info-label">MRN:</span>
+            <span>{{ record.patient.mrn }}</span>
+
+            <span class="info-label">Date of Birth:</span>
+            <span>{{ record.patient.dob|format_date }} (Age: {{ record.patient.age }})</span>
+
+            <span class="info-label">Sex:</span>
+            <span>{{ record.patient.sex }}</span>
+
+            <span class="info-label">Admission Date:</span>
+            <span>{{ record.visit.admission_date|format_date }}</span>
+
+            <span class="info-label">Discharge Date:</span>
+            <span>{{ record.visit.discharge_date|format_date }}</span>
+
+            <span class="info-label">Attending Physician:</span>
+            <span>{{ record.visit.provider }}</span>
+
+            <span class="info-label">Length of Stay:</span>
+            <span>{{ record.visit.length_of_stay or 'N/A' }}</span>
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>ADMISSION DIAGNOSIS</h2>
+        {% if record.admission_diagnoses %}
+        {% for diagnosis in record.admission_diagnoses %}
+        <div class="list-item">
+            {{ loop.index }}. {{ diagnosis.description }}
+            {% if diagnosis.code %} (ICD-10: {{ diagnosis.code }}){% endif %}
+        </div>
+        {% endfor %}
+        {% else %}
+        <div class="list-item">
+            {%- if record.chief_complaint is mapping -%}{{ record.chief_complaint.description or 'Not documented' }}
+            {%- elif record.chief_complaint -%}{{ record.chief_complaint }}
+            {%- else -%}Not documented{%- endif -%}
+        </div>
+        {% endif %}
+    </div>
+
+    <div class="section">
+        <h2>DISCHARGE DIAGNOSIS</h2>
+        {% if record.diagnoses %}
+        {% for diagnosis in record.diagnoses %}
+        <div class="list-item">
+            {{ loop.index }}. {{ diagnosis.description }}
+            {% if diagnosis.code %} (ICD-10: {{ diagnosis.code }}){% endif %}
+        </div>
+        {% endfor %}
+        {% else %}
+        <div class="list-item">Not documented</div>
+        {% endif %}
+    </div>
+
+    <div class="section">
+        <h2>HOSPITAL COURSE</h2>
+        <p>{{ record.notes.hospital_course or record.notes.subjective or 'Patient admitted with above diagnoses. Hospital course was uneventful.' }}</p>
+
+        {% if record.procedures %}
+        <h3 style="font-size: 16px; margin-top: 15px;">Procedures Performed:</h3>
+        {% for procedure in record.procedures %}
+        <div class="list-item">
+            {{ procedure.name }}
+            {% if procedure.date %} ({{ procedure.date|format_date }}){% endif %}
+            {% if procedure.code %} - CPT: {{ procedure.code }}{% endif %}
+        </div>
+        {% if procedure.notes %}
+        <div style="margin-left: 40px; font-size: 14px; color: #666;">
+            {{ procedure.notes }}
+        </div>
+        {% endif %}
+        {% endfor %}
+        {% endif %}
+    </div>
+
+    {% if record.labs %}
+    <div class="section">
+        <h2>SIGNIFICANT LABORATORY FINDINGS</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>Test</th>
+                    <th>Result</th>
+                    <th>Reference Range</th>
+                    <th>Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for lab in record.labs %}
+                <tr {% if lab.abnormal %}style="background: #fff3cd;"{% endif %}>
+                    <td>{{ lab.test_name }}</td>
+                    <td><strong>{{ lab.value }} {{ lab.unit or '' }}</strong></td>
+                    <td>{{ lab.reference_range or 'N/A' }}</td>
+                    <td>{{ lab.date|format_date if lab.date else 'N/A' }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+
+    <div class="section">
+        <h2>DISCHARGE MEDICATIONS</h2>
+        {% if record.medications %}
+        <table>
+            <thead>
+                <tr>
+                    <th>Medication</th>
+                    <th>Dose</th>
+                    <th>Route</th>
+                    <th>Frequency</th>
+                    <th>Instructions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for med in record.medications %}
+                <tr>
+                    <td><strong>{{ med.name }}</strong></td>
+                    <td>{{ med.dose or 'N/A' }}</td>
+                    <td>{{ med.route or 'PO' }}</td>
+                    <td>{{ med.frequency or 'N/A' }}</td>
+                    <td>{{ med.instructions or 'Take as directed' }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p>No medications prescribed at discharge.</p>
+        {% endif %}
+
+        {% if clinical_suggestions and clinical_suggestions.allergy_alerts %}
+        <div class="highlight-box">
+            <strong>⚠️ ALLERGY ALERTS:</strong><br>
+            {% for alert in clinical_suggestions.allergy_alerts %}
+            <div style="margin: 5px 0;">{{ alert.message }}</div>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </div>
+
+    {% if record.allergies %}
+    <div class="section">
+        <h2>ALLERGIES</h2>
+        {% for allergy in record.allergies %}
+        <div class="list-item">
+            <strong>{{ allergy.substance }}</strong>: {{ allergy.reaction }}
+            {% if allergy.severity %} ({{ allergy.severity|capitalize }}){% endif %}
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    <div class="section">
+        <h2>DISCHARGE CONDITION</h2>
+        <p>{{ record.discharge_condition or 'Stable, improved' }}</p>
+    </div>
+
+    <div class="section">
+        <h2>DISCHARGE DISPOSITION</h2>
+        <p>{{ record.discharge_disposition or 'Home with family' }}</p>
+    </div>
+
+    <div class="section">
+        <h2>FOLLOW-UP INSTRUCTIONS</h2>
+        {{ record.notes.plan or 'Patient advised to follow up with primary care physician in 1-2 weeks.' }}
+
+        {% if record.follow_up %}
+        <div style="margin-top: 10px;">
+            <div class="list-item"><strong>Follow-up with:</strong> {{ record.follow_up.provider or 'Primary Care Physician' }}</div>
+            <div class="list-item"><strong>Timeframe:</strong> {{ record.follow_up.timeframe or '1-2 weeks' }}</div>
+            {% if record.follow_up.instructions %}
+            <div class="list-item"><strong>Special Instructions:</strong> {{ record.follow_up.instructions }}</div>
+            {% endif %}
+        </div>
+        {% endif %}
+    </div>
+
+    <div class="section">
+        <h2>PATIENT EDUCATION</h2>
+        <p>{{ record.patient_education or 'Patient educated on diagnosis, treatment plan, and warning signs. Patient verbalized understanding.' }}</p>
+    </div>
+
+    <div class="footer">
+        <div>Discharge Summary Generated: {{ generated_at.strftime('%Y-%m-%d %H:%M:%S') }}</div>
+        <div>Attending Physician: {{ record.visit.provider }}</div>
+        <div style="margin-top: 20px; border-top: 1px solid #333; width: 300px; padding-top: 5px;">
+            Electronically signed by {{ record.visit.provider }}<br>
+            Date: {{ record.visit.discharge_date|format_date or generated_at.strftime('%Y-%m-%d') }}
+        </div>
+    </div>
+</body>
+</html>

--- a/server/templates/progress.html
+++ b/server/templates/progress.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Progress Note - {{ record.visit.date|format_date }}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 40px;
+            line-height: 1.6;
+            color: #333;
+        }
+        .header {
+            border-bottom: 3px solid #2c3e50;
+            padding-bottom: 15px;
+            margin-bottom: 20px;
+        }
+        h1 {
+            color: #2c3e50;
+            margin: 0 0 5px 0;
+            font-size: 22px;
+        }
+        h2 {
+            color: #34495e;
+            font-size: 15px;
+            margin-top: 15px;
+            margin-bottom: 8px;
+            padding-bottom: 3px;
+            border-bottom: 1px solid #ecf0f1;
+        }
+        .patient-info {
+            background: #f8f9fa;
+            padding: 12px;
+            border-left: 4px solid #3498db;
+            margin-bottom: 15px;
+            font-size: 14px;
+        }
+        .info-row {
+            display: inline-block;
+            margin-right: 30px;
+        }
+        .info-label {
+            font-weight: bold;
+        }
+        .section {
+            margin-bottom: 15px;
+        }
+        .section-content {
+            margin-left: 15px;
+            white-space: pre-wrap;
+            font-size: 14px;
+        }
+        .list-item {
+            margin: 3px 0 3px 20px;
+            font-size: 14px;
+        }
+        .vitals-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+            gap: 8px;
+            margin: 8px 0;
+        }
+        .vital-item {
+            background: #f8f9fa;
+            padding: 8px;
+            border-radius: 3px;
+            font-size: 13px;
+        }
+        .vital-label {
+            font-size: 11px;
+            color: #666;
+        }
+        .vital-value {
+            font-size: 15px;
+            font-weight: bold;
+        }
+        .assessment-item {
+            margin: 8px 0;
+            padding: 8px;
+            background: #f8f9fa;
+            border-left: 3px solid #3498db;
+        }
+        .diagnosis-title {
+            font-weight: bold;
+            color: #2c3e50;
+        }
+        .footer {
+            margin-top: 20px;
+            padding-top: 10px;
+            border-top: 1px solid #ecf0f1;
+            font-size: 11px;
+            color: #666;
+        }
+        @media print {
+            body { margin: 15px; font-size: 12px; }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>PROGRESS NOTE</h1>
+        <div style="font-size: 13px; color: #666;">
+            Date: {{ record.visit.date|format_date }} | Time: {{ record.visit.time or 'N/A' }}
+            {% if record.visit.location %} | Location: {{ record.visit.location }}{% endif %}
+        </div>
+    </div>
+
+    <div class="patient-info">
+        <div class="info-row">
+            <span class="info-label">Patient:</span> {{ record.patient.name }}
+        </div>
+        <div class="info-row">
+            <span class="info-label">MRN:</span> {{ record.patient.mrn }}
+        </div>
+        <div class="info-row">
+            <span class="info-label">Age/Sex:</span> {{ record.patient.age }}/{{ record.patient.sex }}
+        </div>
+        <div class="info-row">
+            <span class="info-label">Provider:</span> {{ record.visit.provider }}
+        </div>
+        {% if record.visit.day_of_stay %}
+        <div class="info-row">
+            <span class="info-label">Hospital Day:</span> {{ record.visit.day_of_stay }}
+        </div>
+        {% endif %}
+    </div>
+
+    {% if record.interval_history or record.notes.subjective %}
+    <div class="section">
+        <h2>INTERVAL HISTORY / SUBJECTIVE</h2>
+        <div class="section-content">
+            {{ record.interval_history or record.notes.subjective or 'Patient continues on current treatment plan. No new complaints.' }}
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="section">
+        <h2>VITAL SIGNS</h2>
+        {% if record.vital_signs %}
+        <div class="vitals-grid">
+            {% if record.vital_signs.temperature %}
+            <div class="vital-item">
+                <div class="vital-label">Temperature</div>
+                <div class="vital-value">{{ record.vital_signs.temperature }}</div>
+            </div>
+            {% endif %}
+            {% if record.vital_signs.blood_pressure %}
+            <div class="vital-item">
+                <div class="vital-label">Blood Pressure</div>
+                <div class="vital-value">{{ record.vital_signs.blood_pressure }}</div>
+            </div>
+            {% endif %}
+            {% if record.vital_signs.heart_rate %}
+            <div class="vital-item">
+                <div class="vital-label">Heart Rate</div>
+                <div class="vital-value">{{ record.vital_signs.heart_rate }}</div>
+            </div>
+            {% endif %}
+            {% if record.vital_signs.respiratory_rate %}
+            <div class="vital-item">
+                <div class="vital-label">Resp Rate</div>
+                <div class="vital-value">{{ record.vital_signs.respiratory_rate }}</div>
+            </div>
+            {% endif %}
+            {% if record.vital_signs.oxygen_saturation %}
+            <div class="vital-item">
+                <div class="vital-label">O2 Sat</div>
+                <div class="vital-value">{{ record.vital_signs.oxygen_saturation }}</div>
+            </div>
+            {% endif %}
+            {% if record.vital_signs.weight %}
+            <div class="vital-item">
+                <div class="vital-label">Weight</div>
+                <div class="vital-value">{{ record.vital_signs.weight }}</div>
+            </div>
+            {% endif %}
+        </div>
+        {% else %}
+        <div class="section-content">Not documented</div>
+        {% endif %}
+    </div>
+
+    <div class="section">
+        <h2>PHYSICAL EXAMINATION</h2>
+        <div class="section-content">
+            {{ record.notes.objective or record.physical_exam or 'Patient appears comfortable. General exam unremarkable.' }}
+        </div>
+    </div>
+
+    {% if record.labs %}
+    <div class="section">
+        <h2>LABORATORY / STUDIES</h2>
+        {% for lab in record.labs %}
+        <div class="list-item">
+            {{ lab.test_name }}: {{ lab.value }} {{ lab.unit or '' }}
+            {% if lab.abnormal %}<strong>({{ lab.abnormal_flag or 'Abnormal' }})</strong>{% endif %}
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    <div class="section">
+        <h2>ASSESSMENT AND PLAN</h2>
+        {% if record.diagnoses %}
+        {% for diagnosis in record.diagnoses %}
+        <div class="assessment-item">
+            <div class="diagnosis-title">
+                {{ loop.index }}. {{ diagnosis.description }}
+                {% if diagnosis.code %} ({{ diagnosis.code }}){% endif %}
+                {% if diagnosis.status %} - {{ diagnosis.status|capitalize }}{% endif %}
+            </div>
+            {% if diagnosis.plan %}
+            <div style="margin-top: 5px; margin-left: 15px; font-size: 13px;">
+                {{ diagnosis.plan }}
+            </div>
+            {% endif %}
+        </div>
+        {% endfor %}
+        {% else %}
+        <div class="section-content">
+            {{ record.notes.assessment or 'Not documented' }}
+        </div>
+        {% endif %}
+
+        {% if record.notes.plan and not record.diagnoses %}
+        <div style="margin-top: 10px;">
+            <strong>Plan:</strong>
+            <div class="section-content">{{ record.notes.plan }}</div>
+        </div>
+        {% endif %}
+    </div>
+
+    {% if record.medications %}
+    <div class="section">
+        <h2>CURRENT MEDICATIONS</h2>
+        {% for med in record.medications %}
+        <div class="list-item">
+            {{ med.name }}
+            {% if med.dose %} {{ med.dose }}{% endif %}
+            {% if med.route %} {{ med.route }}{% endif %}
+            {% if med.frequency %} {{ med.frequency }}{% endif %}
+            {% if med.status == 'new' %}<strong>(NEW)</strong>{% endif %}
+            {% if med.status == 'changed' %}<strong>(CHANGED)</strong>{% endif %}
+            {% if med.status == 'discontinued' %}<strong>(DISCONTINUED)</strong>{% endif %}
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    {% if record.orders %}
+    <div class="section">
+        <h2>NEW ORDERS</h2>
+        {% for order in record.orders %}
+        <div class="list-item">{{ order }}</div>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    {% if record.disposition %}
+    <div class="section">
+        <h2>DISPOSITION</h2>
+        <div class="section-content">
+            {{ record.disposition }}
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="footer">
+        <div>Progress Note Generated: {{ generated_at.strftime('%Y-%m-%d %H:%M:%S') }}</div>
+        <div style="margin-top: 10px;">
+            Electronically documented by {{ record.visit.provider }}
+        </div>
+    </div>
+</body>
+</html>

--- a/server/templates/soap.html
+++ b/server/templates/soap.html
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SOAP Note - {{ record.visit.date|format_date }}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 40px;
+            line-height: 1.6;
+            color: #333;
+        }
+        .header {
+            border-bottom: 3px solid #2c3e50;
+            padding-bottom: 15px;
+            margin-bottom: 20px;
+        }
+        h1 {
+            color: #2c3e50;
+            margin: 0 0 10px 0;
+            font-size: 24px;
+        }
+        .patient-info {
+            background: #f8f9fa;
+            padding: 15px;
+            border-left: 4px solid #3498db;
+            margin-bottom: 20px;
+        }
+        .patient-info table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .patient-info td {
+            padding: 5px 10px;
+        }
+        .patient-info td:first-child {
+            font-weight: bold;
+            width: 150px;
+        }
+        .alerts {
+            background: #fff3cd;
+            border-left: 4px solid #ff9800;
+            padding: 15px;
+            margin-bottom: 20px;
+        }
+        .alerts.critical {
+            background: #f8d7da;
+            border-left-color: #dc3545;
+        }
+        .alert-item {
+            margin: 10px 0;
+            padding: 8px;
+            background: white;
+            border-radius: 4px;
+        }
+        .alert-icon {
+            font-weight: bold;
+            margin-right: 8px;
+        }
+        .section {
+            margin-bottom: 25px;
+        }
+        .section-header {
+            font-weight: bold;
+            font-size: 16px;
+            color: #2c3e50;
+            margin-bottom: 10px;
+            padding-bottom: 5px;
+            border-bottom: 2px solid #ecf0f1;
+        }
+        .section-content {
+            margin-left: 15px;
+            white-space: pre-wrap;
+        }
+        .list-item {
+            margin: 5px 0 5px 20px;
+        }
+        .vitals {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 10px;
+            margin: 10px 0;
+        }
+        .vital-box {
+            background: #f8f9fa;
+            padding: 10px;
+            border-radius: 4px;
+        }
+        .vital-label {
+            font-size: 12px;
+            color: #666;
+        }
+        .vital-value {
+            font-size: 18px;
+            font-weight: bold;
+            color: #2c3e50;
+        }
+        .footer {
+            margin-top: 40px;
+            padding-top: 15px;
+            border-top: 2px solid #ecf0f1;
+            font-size: 12px;
+            color: #666;
+        }
+        .signature-line {
+            margin-top: 30px;
+            border-top: 1px solid #333;
+            width: 300px;
+            padding-top: 5px;
+        }
+        @media print {
+            body { margin: 20px; }
+            .alerts { page-break-inside: avoid; }
+            .section { page-break-inside: avoid; }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>SOAP Note</h1>
+        <div style="font-size: 14px; color: #666;">
+            Date: {{ record.visit.date|format_date }} | Time: {{ record.visit.time or 'N/A' }}
+        </div>
+    </div>
+
+    <div class="patient-info">
+        <table>
+            <tr>
+                <td>Patient:</td>
+                <td><strong>{{ record.patient.name }}</strong></td>
+                <td>MRN:</td>
+                <td><strong>{{ record.patient.mrn }}</strong></td>
+            </tr>
+            <tr>
+                <td>DOB:</td>
+                <td>{{ record.patient.dob|format_date }} (Age: {{ record.patient.age }})</td>
+                <td>Sex:</td>
+                <td>{{ record.patient.sex }}</td>
+            </tr>
+            <tr>
+                <td>Provider:</td>
+                <td>{{ record.visit.provider }}</td>
+                <td>Visit Type:</td>
+                <td>{{ record.visit.type or 'Office Visit' }}</td>
+            </tr>
+        </table>
+    </div>
+
+    {% if clinical_suggestions and (clinical_suggestions.allergy_alerts or clinical_suggestions.drug_interactions) %}
+    <div class="alerts {% if clinical_suggestions.risk_level == 'critical' %}critical{% endif %}">
+        <div style="font-weight: bold; font-size: 16px; margin-bottom: 10px;">
+            ⚠️ CLINICAL ALERTS (Risk Level: {{ clinical_suggestions.risk_level|upper }})
+        </div>
+
+        {% if clinical_suggestions.allergy_alerts %}
+        {% for alert in clinical_suggestions.allergy_alerts %}
+        <div class="alert-item">
+            <span class="alert-icon">🚨</span>
+            <strong>ALLERGY ALERT:</strong> {{ alert.message }}<br>
+            <small style="margin-left: 25px;">
+                Reaction: {{ alert.reaction }} ({{ alert.allergy_severity }})<br>
+                Recommendation: {{ alert.recommendation }}
+            </small>
+        </div>
+        {% endfor %}
+        {% endif %}
+
+        {% if clinical_suggestions.drug_interactions %}
+        {% for interaction in clinical_suggestions.drug_interactions %}
+        <div class="alert-item">
+            <span class="alert-icon">⚡</span>
+            <strong>INTERACTION ({{ interaction.severity|upper }}):</strong> {{ interaction.message }}<br>
+            <small style="margin-left: 25px;">
+                Effect: {{ interaction.effect }}<br>
+                Recommendation: {{ interaction.recommendation }}
+            </small>
+        </div>
+        {% endfor %}
+        {% endif %}
+    </div>
+    {% endif %}
+
+    <div class="section">
+        <div class="section-header">CHIEF COMPLAINT</div>
+        <div class="section-content">
+            {% if record.chief_complaint is mapping %}
+                {{ record.chief_complaint.description or 'Not documented' }}
+            {% elif record.chief_complaint %}
+                {{ record.chief_complaint }}
+            {% else %}
+                Not documented
+            {% endif %}
+        </div>
+    </div>
+
+    <div class="section">
+        <div class="section-header">SUBJECTIVE</div>
+        <div class="section-content">
+            {{ record.notes.subjective or 'No subjective findings documented' }}
+        </div>
+    </div>
+
+    <div class="section">
+        <div class="section-header">OBJECTIVE</div>
+        <div class="section-content">
+            {% if record.vital_signs %}
+            <div class="vitals">
+                {% if record.vital_signs.temperature %}
+                <div class="vital-box">
+                    <div class="vital-label">Temperature</div>
+                    <div class="vital-value">{{ record.vital_signs.temperature }}</div>
+                </div>
+                {% endif %}
+                {% if record.vital_signs.blood_pressure %}
+                <div class="vital-box">
+                    <div class="vital-label">Blood Pressure</div>
+                    <div class="vital-value">{{ record.vital_signs.blood_pressure }}</div>
+                </div>
+                {% endif %}
+                {% if record.vital_signs.heart_rate %}
+                <div class="vital-box">
+                    <div class="vital-label">Heart Rate</div>
+                    <div class="vital-value">{{ record.vital_signs.heart_rate }}</div>
+                </div>
+                {% endif %}
+                {% if record.vital_signs.respiratory_rate %}
+                <div class="vital-box">
+                    <div class="vital-label">Respiratory Rate</div>
+                    <div class="vital-value">{{ record.vital_signs.respiratory_rate }}</div>
+                </div>
+                {% endif %}
+                {% if record.vital_signs.oxygen_saturation %}
+                <div class="vital-box">
+                    <div class="vital-label">O2 Saturation</div>
+                    <div class="vital-value">{{ record.vital_signs.oxygen_saturation }}</div>
+                </div>
+                {% endif %}
+            </div>
+            {% endif %}
+
+            <div style="margin-top: 15px;">
+                {{ record.notes.objective or 'No objective findings documented' }}
+            </div>
+        </div>
+    </div>
+
+    <div class="section">
+        <div class="section-header">ASSESSMENT</div>
+        <div class="section-content">
+            {% if record.diagnoses %}
+            {% for diagnosis in record.diagnoses %}
+            <div class="list-item">
+                {{ loop.index }}. {{ diagnosis.description }}
+                {% if diagnosis.code %} ({{ diagnosis.code }}){% endif %}
+                {% if diagnosis.status %} - {{ diagnosis.status|capitalize }}{% endif %}
+            </div>
+            {% endfor %}
+            {% else %}
+            {{ record.notes.assessment or 'No assessment documented' }}
+            {% endif %}
+        </div>
+    </div>
+
+    <div class="section">
+        <div class="section-header">PLAN</div>
+        <div class="section-content">
+            {{ record.notes.plan or 'No plan documented' }}
+
+            {% if record.medications %}
+            <div style="margin-top: 15px;">
+                <strong>Medications Prescribed:</strong>
+                {% for med in record.medications %}
+                <div class="list-item">
+                    {{ med.name }}
+                    {% if med.dose %} {{ med.dose }}{% endif %}
+                    {% if med.route %} {{ med.route }}{% endif %}
+                    {% if med.frequency %} {{ med.frequency }}{% endif %}
+                </div>
+                {% endfor %}
+            </div>
+            {% endif %}
+
+            {% if record.labs %}
+            <div style="margin-top: 15px;">
+                <strong>Labs Ordered:</strong>
+                {% for lab in record.labs %}
+                <div class="list-item">{{ lab.test_name or lab }}</div>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if record.allergies %}
+    <div class="section">
+        <div class="section-header">ALLERGIES</div>
+        <div class="section-content">
+            {% for allergy in record.allergies %}
+            <div class="list-item">
+                <strong>{{ allergy.substance }}</strong>: {{ allergy.reaction }}
+                {% if allergy.severity %} ({{ allergy.severity|capitalize }}){% endif %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="footer">
+        <div>Generated: {{ generated_at.strftime('%Y-%m-%d %H:%M:%S') }}</div>
+        <div>Generator Version: {{ generator_version }}</div>
+        {% if clinical_suggestions %}
+        <div style="margin-top: 10px; font-style: italic;">
+            Clinical decision support provided. Review all alerts before finalizing.
+        </div>
+        {% endif %}
+    </div>
+
+    <div class="signature-line">
+        Electronically signed by {{ record.visit.provider }}<br>
+        Date: {{ record.visit.date|format_date }}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
… templates

- RecordGenerator: selects SOAP/discharge/consultation/progress Jinja2 template, renders HTML, converts to PDF via WeasyPrint or plain text
- ExportService: packages generated documents for download, stores to S3/local
- Jinja2 templates for all four record types with CSS print styles
- POST /api/records/generate  render from StructuredRecord dict
- POST /api/records/preview  return HTML response in browser
- POST /api/records/regenerate  incorporate physician feedback diff
- POST /api/records/commit  persist physician-approved record version
- GET  /api/records/patient/{id}/history  versioned record history
- GET  /api/records/templates  list available template names